### PR TITLE
Passing custom primary key name to returning clause

### DIFF
--- a/src/Commands/Store.php
+++ b/src/Commands/Store.php
@@ -557,10 +557,10 @@ class Store extends Command
 		$entity = $this->entity;
 
 		$attributes = $this->getRawAttributes();
-		
-		$id = $this->query->insertGetId($attributes);
 
-		$keyName = $this->entityMap->getKeyName();
+        $keyName = $this->entityMap->getKeyName();
+		
+		$id = $this->query->insertGetId($attributes, $keyName);
 		
 		$entity->$keyName = $id;
 	}


### PR DESCRIPTION
When using a custom primary key name the RETURNING clause (in postgresql) is using standard "id" key instead of the custom one.
