### PR TITLE
Rename interfaces to match Laravel 5

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -3,10 +3,10 @@
 use ArrayAccess;
 use JsonSerializable;
 use Analogue\ORM\System\ProxyInterface;
-use Illuminate\Support\Contracts\JsonableInterface;
-use Illuminate\Support\Contracts\ArrayableInterface;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Contracts\Support\Arrayable;
 
-class Entity extends ValueObject implements ArrayAccess, JsonableInterface, JsonSerializable, ArrayableInterface{
+class Entity extends ValueObject implements ArrayAccess, Jsonable, JsonSerializable, Arrayable {
 
 	/**
 	 * Return the entity's attribute 

--- a/src/ValueObject.php
+++ b/src/ValueObject.php
@@ -2,10 +2,10 @@
 
 use ArrayAccess;
 use JsonSerializable;
-use Illuminate\Support\Contracts\JsonableInterface;
-use Illuminate\Support\Contracts\ArrayableInterface;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Contracts\Support\Arrayable;
 
-class ValueObject implements ArrayAccess, JsonableInterface, JsonSerializable, ArrayableInterface {
+class ValueObject implements ArrayAccess, Jsonable, JsonSerializable, Arrayable {
 
 	protected $attributes;
 


### PR DESCRIPTION
The names of JsonableInterface and ArrayableInterface were changed in Laravel 5.
https://github.com/laravel/framework/commit/26982391b8ecf8f9160cec324c74ded96861f2b6

Unfortunately this will break backwards compatibility with L4, but I don't really see an alternative.