### PR TITLE
Fix of the isRegisteredEntity() method

### DIFF
--- a/src/System/Manager.php
+++ b/src/System/Manager.php
@@ -304,7 +304,7 @@ class Manager {
 	{
 		if (! is_string($entity)) $entity = get_class($entity);
 
-		return in_array($entity, $this->entityClasses) ? true: false;
+		return array_key_exists($entity, $this->entityClasses);
 	}
 
 	/**


### PR DESCRIPTION
Previously it returned false results - since the `$entityClasses` property is an associative array, it always returned false regardless of whether the entity was previously registered (`in_array()` searched for entities in the array values which are the mappers).