### PR TITLE
[Feature] be able to watch value-objects for changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "illuminate/database": "5.*",
-        "illuminate/events": "5.*",
-        "illuminate/pagination": "5.*"
+        "php": ">=5.5.0",
+        "illuminate/database": "~5.0",
+        "illuminate/events": "~5.0",
+        "illuminate/pagination": "~5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,10 @@
 # Analogue ORM 
 [![Build Status](https://travis-ci.org/analogueorm/analogue.svg)](https://travis-ci.org/analogueorm/analogue)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/analogueorm/analogue/badges/quality-score.png?b=5.1)](https://scrutinizer-ci.com/g/analogueorm/analogue/?branch=5.1)
 [![Latest Version](https://img.shields.io/github/release/analogueorm/analogue.svg?style=flat-square)](https://github.com/analogueorm/analogue/releases)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE)
+
+> **IMPORTANT** : In a matter of simplification, Analogue ORM versions have been pushed to mirror the corresponding Illuminate dependency. Please update your composer.json accordingly. 
 
 **Analogue** is a flexible, easy-to-use **Data Mapper ORM** for **PHP**. It provides a quick and intuitive way to query and persist custom domain objects into a SQL Database. 
 
@@ -48,12 +51,18 @@ Check the [Documentation](https://github.com/analogueorm/analogue/wiki) for more
 ## Install :
 
 ```
-composer require analogue/orm:2.1.*
+composer require analogue/orm:5.1.*
 ```
 
 See [Configuration](https://github.com/analogueorm/analogue/wiki/Installation) for more information.
 
 ##Changelog 
+
+####Version 5.1
+- Illuminate 5.1 Compatibility. 
+
+####Version 5.0
+- Analogue version now mirrors illuminate version. 
 
 ####Version 2.1.3
 - Mutator feature in base Entity class

--- a/src/Commands/Store.php
+++ b/src/Commands/Store.php
@@ -651,7 +651,9 @@ class Store extends Command
 		}	
 		else
 		{
-			$id = $this->query->insertGetId($attributes);
+			$sequence = $this->entityMap->getSequence();
+
+			$id = $this->query->insertGetId($attributes, $sequence);
 
 			$entity->setEntityAttribute($keyName, $id);
 		}

--- a/src/EntityCollection.php
+++ b/src/EntityCollection.php
@@ -1,10 +1,12 @@
 <?php
+
 namespace Analogue\ORM;
 
 use InvalidArgumentException;
 use Analogue\ORM\Mappable;
 use Analogue\ORM\System\Manager;
-use Illuminate\Support\Collection as Collection;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Arr;
 
 class EntityCollection extends Collection {
 	
@@ -165,36 +167,6 @@ class EntityCollection extends Collection {
 	}
 
 	/**
-	 * Get the max value of a given key.
-	 *
-	 * @param  string  $key
-	 * @return mixed
-	 */
-	public function max($key)
-	{
-		return $this->reduce(function($result, $item) use ($key)
-		{
-			return (is_null($result) || $item->getEntityAttribute($key) > $result) ? 
-				$item->getEntityAttribute($key) : $result;
-		});
-	}
-
-	/**
-	 * Get the min value of a given key.
-	 *
-	 * @param  string  $key
-	 * @return mixed
-	 */
-	public function min($key)
-	{
-		return $this->reduce(function($result, $item) use ($key)
-		{
-			return (is_null($result) || $item->getEntityAttribute($key) < $result) 
-				? $item->getEntityAttribute($key) : $result;
-		});
-	}
-
-	/**
 	 * Generic function for returning class.key value pairs
 	 * 
 	 * @return string
@@ -305,18 +277,6 @@ class EntityCollection extends Collection {
 	}
 
 	/**
-	 * Return only unique items from the collection.
-	 *
-	 * @return static
-	 */
-	public function unique()
-	{
-		$dictionary = $this->getDictionary();
-
-		return new static(array_values($dictionary));
-	}
-
-	/**
 	 * Returns only the models from the collection with the specified keys.
 	 *
 	 * @param  mixed  $keys
@@ -375,12 +335,78 @@ class EntityCollection extends Collection {
 	}
 
 	/**
+	 * Get the max value of a given key.
+	 *
+	 * @param  string  $key
+	 * @return mixed
+	 */
+	public function max($key = null)
+	{
+		return $this->reduce(function($result, $item) use ($key)
+		{
+			return (is_null($result) || $item->getEntityAttribute($key) > $result) ? 
+				$item->getEntityAttribute($key) : $result;
+		});
+	}
+
+	/**
+	 * Get the min value of a given key.
+	 *
+	 * @param  string  $key
+	 * @return mixed
+	 */
+	public function min($key = null)
+	{
+		return $this->reduce(function($result, $item) use ($key)
+		{
+			return (is_null($result) || $item->getEntityAttribute($key) < $result) 
+				? $item->getEntityAttribute($key) : $result;
+		});
+	}
+
+	/**
+     * Get an array with the values of a given key.
+     *
+     * @param  string  $value
+     * @param  string  $key
+     * @return static
+     */
+    public function pluck($value, $key = null)
+    {
+    	return new Collection(Arr::pluck($this->items, $value, $key));
+    }
+
+    /**
+     * Alias for the "pluck" method.
+     *
+     * @param  string  $value
+     * @param  string  $key
+     * @return static
+     */
+    public function lists($value, $key = null)
+    {
+        return $this->pluck($value, $key);
+    }
+
+	/**
+	 * Return only unique items from the collection.
+	 *
+	 * @return static
+	 */
+	public function unique($key = null)
+	{
+		$dictionary = $this->getDictionary();
+
+		return new static(array_values($dictionary));
+	}
+
+	/**
 	 * Get a base Support collection instance from this collection.
 	 *
 	 * @return \Illuminate\Support\Collection
 	 */
 	public function toBase()
 	{
-		return new BaseCollection($this->items);
+		return new Collection($this->items);
 	}
 }

--- a/src/EntityMap.php
+++ b/src/EntityMap.php
@@ -110,6 +110,14 @@ class EntityMap {
 	protected $morphClass;
 
 	/**
+	 * Sequence name, to be used with postgreSql
+	 * defaults to %table_name%_id_seq
+	 *
+	 * @var string
+	 */
+	protected $sequence = null;
+
+	/**
 	 * Indicates if the entity should be timestamped.
 	 *
 	 * @var bool
@@ -255,6 +263,23 @@ class EntityMap {
 	public function setTable($table)
 	{
 		$this->table = $table;
+	}
+
+	/**
+	 * Get the pgSql sequence name
+	 * 
+	 * @return string
+	 */
+	public function getSequence()
+	{
+		if (! is_null($this->sequence))
+		{
+			return $this->sequence;
+		}
+		else
+		{
+			return $this->getTable().'_id_seq';
+		}
 	}
 
 	/**

--- a/src/System/EntityBuilder.php
+++ b/src/System/EntityBuilder.php
@@ -72,7 +72,7 @@ class EntityBuilder {
             $tmpCache[$resultArray[$keyName] ] = $resultArray;
 
             // Hydrate any embedded Value Object
-            $this->hydrateValueObjects($resultArray);
+            $this->hydrateValueObjects($resultArray, $instance);
 
             $instance->setEntityAttributes($resultArray);
 
@@ -97,11 +97,12 @@ class EntityBuilder {
      * @param  array $attributes 
      * @return void
      */
-    protected function hydrateValueObjects(& $attributes)
+    protected function hydrateValueObjects(& $attributes, $entity)
     {
         foreach($this->entityMap->getEmbeddables() as $localKey => $valueClass)
         {
             $this->hydrateValueObject($attributes, $localKey, $valueClass);
+            $attributes[$localKey]->setWatcher($entity);
         }   
     }
 

--- a/src/System/Manager.php
+++ b/src/System/Manager.php
@@ -86,6 +86,16 @@ class Manager {
 	}
 
 	/**
+	 * Return the Driver Manager's instance
+	 * 
+	 * @return \Analogue\ORM\Drivers\Manager 
+	 */
+	public function getDriverManager()
+	{
+		return $this->drivers;
+	}
+
+	/**
 	 * Create a mapper for a given entity
 	 * 
 	 * @param \Analogue\ORM\Mappable|string $entity

--- a/src/System/Query.php
+++ b/src/System/Query.php
@@ -797,6 +797,16 @@ class Query {
 	}
 
 	/**
+	 * Get a new query builder without any scope applied.
+	 * 
+	 * @return \Analogue\ORM\System\Query
+	 */
+	public function newQueryWithoutScopes()
+	{
+		return new Query($this->mapper, $this->adapter);
+	}
+
+	/**
 	 * Get the Mapper instance for this Query Builder
 	 * 
 	 * @return \Analogue\ORM\System\Mapper

--- a/src/ValueObject.php
+++ b/src/ValueObject.php
@@ -10,6 +10,8 @@ use Carbon\Carbon;
 class ValueObject implements Mappable, ArrayAccess, Jsonable, JsonSerializable, Arrayable {
 	use MappableTrait;
 
+    protected $watcher;
+
     /**
      * Dynamically retrieve attributes on the entity.
      *
@@ -171,5 +173,10 @@ class ValueObject implements Mappable, ArrayAccess, Jsonable, JsonSerializable, 
             }
         }
         return $attributes;
+    }
+
+    public function setWatcher($watcher)
+    {
+        $this->watcher = $watcher;
     }
 }

--- a/src/ValueObject.php
+++ b/src/ValueObject.php
@@ -31,6 +31,13 @@ class ValueObject implements Mappable, ArrayAccess, Jsonable, JsonSerializable, 
     public function __set($key, $value)
     {
         $this->attributes[$key] = $value;
+
+        $class = class_basename($this);
+
+        if (method_exists($this->watcher, camel_case($class).'Changed'))
+        {
+            $this->watcher->{camel_case($class).'Changed'}($this);
+        }
     }
 
     /**

--- a/tests/AnalogueTest/EntityCollectionTest.php
+++ b/tests/AnalogueTest/EntityCollectionTest.php
@@ -2,6 +2,7 @@
 
 use Analogue\ORM\Entity;
 use Analogue\ORM\EntityCollection as Collection;
+use Illuminate\Support\Collection as IlluminateCollection;
 use PHPUnit_Framework_TestCase;
 
 class EntityCollectionTest extends PHPUnit_Framework_TestCase {
@@ -191,8 +192,8 @@ class EntityCollectionTest extends PHPUnit_Framework_TestCase {
         $e2->name = 'bar';
 
         $data = new Collection([$e1,$e2]);
-        $this->assertEquals(['f' => 'foo', 'b' => 'bar'], $data->lists('name', 'uid'));
-        $this->assertEquals(['foo', 'bar'], $data->lists('name'));
+        $this->assertEquals(new IlluminateCollection(['f' => 'foo', 'b' => 'bar']), $data->lists('name', 'uid'));
+        $this->assertEquals(new IlluminateCollection(['foo', 'bar']), $data->lists('name'));
     }
 
     

--- a/tests/AnalogueTest/QueryTest.php
+++ b/tests/AnalogueTest/QueryTest.php
@@ -244,4 +244,20 @@ class QueryTest extends PHPUnit_Framework_TestCase {
         $paginator = $mapper->query()->simplePaginate(5);
         $this->assertEquals(5, count($paginator));
     }
+
+    public function testWhereBlock()
+    {
+        $mapper = get_mapper('AnalogueTest\App\Permission');
+        $p1 = new Permission('ozzy');
+        $p2 = new Permission('osbourne');
+        $c = new EntityCollection([$p1,$p2]);
+        $mapper->store($c);
+
+        $r = $mapper->query()->where(function ($query) {
+            $query->where('label', 'ozzy')
+                  ->orWhere('label', 'osbourne');
+        })->get();
+
+        $this->assertEquals(2, $r->count());
+    }
 }


### PR DESCRIPTION
So I have a `Person` with a value-object `Identity`, with attributes like `name` and `surname`. The person also has an attribute called `slug`, which is based on the `name` and `surname` of `Identity`. So in order to keep `slug` up to date, I need to be able to watch `Identity` for changes. Well that's what this pull-request is for. It makes the following code possible:

    class Person extends Entity
    {
        public function identityChanged($identity)
        {
            $this->attributes['slug'] = str_slug($identity->name . ' ' . $identity->surname);
        }
    }