### PR TITLE
added missing queryNoScopes method to Query class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "illuminate/database": "5.0.*",
-        "illuminate/events": "5.0.*",
-        "illuminate/pagination": "5.0.*"
+        "php": ">=5.5.9",
+        "illuminate/database": ">=5.1.0",
+        "illuminate/events": ">=5.1.0",
+        "illuminate/pagination": ">=5.1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"

--- a/src/EntityCollection.php
+++ b/src/EntityCollection.php
@@ -170,7 +170,7 @@ class EntityCollection extends Collection {
 	 * @param  string  $key
 	 * @return mixed
 	 */
-	public function max($key)
+	public function max($key = null)
 	{
 		return $this->reduce(function($result, $item) use ($key)
 		{
@@ -185,7 +185,7 @@ class EntityCollection extends Collection {
 	 * @param  string  $key
 	 * @return mixed
 	 */
-	public function min($key)
+	public function min($key = null)
 	{
 		return $this->reduce(function($result, $item) use ($key)
 		{
@@ -309,7 +309,7 @@ class EntityCollection extends Collection {
 	 *
 	 * @return static
 	 */
-	public function unique()
+	public function unique($key = null)
 	{
 		$dictionary = $this->getDictionary();
 

--- a/src/EntityCollection.php
+++ b/src/EntityCollection.php
@@ -5,6 +5,7 @@ use InvalidArgumentException;
 use Analogue\ORM\Mappable;
 use Analogue\ORM\System\Manager;
 use Illuminate\Support\Collection as Collection;
+use Illuminate\Support\Arr;
 
 class EntityCollection extends Collection {
 	
@@ -80,6 +81,18 @@ class EntityCollection extends Collection {
 
 		return $this->pull($entity->getEntityAttribute($keyName));
 	}
+
+    /**
+     * Get an array with the values of a given key.
+     *
+     * @param  string  $value
+     * @param  string  $key
+     * @return static
+     */
+    public function pluck($value, $key = null)
+    {
+        return new Collection(Arr::pluck($this->items, $value, $key));
+    }
 
 	/**
 	 * Push an item onto the beginning of the collection.

--- a/src/System/Query.php
+++ b/src/System/Query.php
@@ -796,6 +796,11 @@ class Query {
 		return $this->applyGlobalScopes($builder);
 	}
 
+	public function newQueryWithoutScopes()
+	{
+		return new Query($this->mapper, $this->adapter);
+	}
+
 	/**
 	 * Get the Mapper instance for this Query Builder
 	 * 

--- a/tests/AnalogueTest/EntityCollectionTest.php
+++ b/tests/AnalogueTest/EntityCollectionTest.php
@@ -2,6 +2,7 @@
 
 use Analogue\ORM\Entity;
 use Analogue\ORM\EntityCollection as Collection;
+use Illuminate\Support\Collection as IlluminateCollection;
 use PHPUnit_Framework_TestCase;
 
 class EntityCollectionTest extends PHPUnit_Framework_TestCase {
@@ -191,8 +192,8 @@ class EntityCollectionTest extends PHPUnit_Framework_TestCase {
         $e2->name = 'bar';
 
         $data = new Collection([$e1,$e2]);
-        $this->assertEquals(['f' => 'foo', 'b' => 'bar'], $data->lists('name', 'uid'));
-        $this->assertEquals(['foo', 'bar'], $data->lists('name'));
+        $this->assertEquals(new IlluminateCollection(['f' => 'foo', 'b' => 'bar']), $data->lists('name', 'uid'));
+        $this->assertEquals(new IlluminateCollection(['foo', 'bar']), $data->lists('name'));
     }
 
     

--- a/tests/AnalogueTest/QueryTest.php
+++ b/tests/AnalogueTest/QueryTest.php
@@ -146,6 +146,22 @@ class QueryTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals(2, $r->count());
     }
 
+    public function testWhereBlock()
+    {
+        $mapper = get_mapper('AnalogueTest\App\Permission');
+        $p1 = new Permission('michael');
+        $p2 = new Permission('jackson');
+        $c = new EntityCollection([$p1,$p2]);
+        $mapper->store($c);
+
+        $r = $mapper->query()->where(function ($query) {
+            $query->where('label', 'jackson')
+                  ->orWhere('label', 'norris');
+        })->get();
+
+        $this->assertEquals(3, $r->count());
+    }
+
     public function testHas()
     {
         $mapper = get_mapper('AnalogueTest\App\Role');


### PR DESCRIPTION
I don't know the internals of Analogue well enough to know if this is quite right, but it seems to work for some basic test cases.