### PR TITLE
prevent error when an entity-map has a method that is not for a relationship

### DIFF
--- a/src/System/MapInitializer.php
+++ b/src/System/MapInitializer.php
@@ -58,6 +58,8 @@ class MapInitializer {
 
 			$params = $method->getParameters();
 
+			if($params[0]->getClass() == null) continue;
+
 			if ($params[0]->getClass()->implementsInterface('Analogue\ORM\Mappable'))
 			{
 				$relationships[] = $methodName;


### PR DESCRIPTION
Well the title is a bit confusing, because the place I encountered this error actually did have to do with a relationship.

You see in a project I was working on, I needed to create a new type of relationship called `HasTranslations`. It was based on the `HasMany` relationship, with the difference that the related translations that were found were put directly on the entity, instead of via a `translations` attribute on the entity.

So in order to make this work I needed to make a BaseEntityMap which has a method like this:

    public function hasTranslations($entity, $relatedTable, $foreignKey = 'foreign_key', $localKey = null)
    {
        $foreignKey = $foreignKey ?: $this->getForeignKey();

        $relatedMap = new EntityMap;

        $relatedMap->setTable($relatedTable);

        $table = $relatedTable.'.'.$foreignKey;

        $localKey = $localKey ?: $this->getKeyName();

        return with(new HasTranslations($relatedMap, $entity, $table , $localKey))
            ->where('model', $this->getMorphClass())
            ->where('locale', 'eng');
    }

And that would trigger an error, because the first argument did not have the Entity class type. And if it did, well then Analogue would assume I'm trying to do something I'm not.