### PR TITLE
[Feature] be able to watch value-objects for changes

### DIFF
--- a/src/System/EntityBuilder.php
+++ b/src/System/EntityBuilder.php
@@ -72,7 +72,7 @@ class EntityBuilder {
             $tmpCache[$resultArray[$keyName] ] = $resultArray;
 
             // Hydrate any embedded Value Object
-            $this->hydrateValueObjects($resultArray);
+            $this->hydrateValueObjects($resultArray, $instance);
 
             $instance->setEntityAttributes($resultArray);
 
@@ -97,11 +97,12 @@ class EntityBuilder {
      * @param  array $attributes 
      * @return void
      */
-    protected function hydrateValueObjects(& $attributes)
+    protected function hydrateValueObjects(& $attributes, $entity)
     {
         foreach($this->entityMap->getEmbeddables() as $localKey => $valueClass)
         {
             $this->hydrateValueObject($attributes, $localKey, $valueClass);
+            $attributes[$localKey]->setWatcher($entity);
         }   
     }
 

--- a/src/ValueObject.php
+++ b/src/ValueObject.php
@@ -10,6 +10,8 @@ use Carbon\Carbon;
 class ValueObject implements Mappable, ArrayAccess, Jsonable, JsonSerializable, Arrayable {
 	use MappableTrait;
 
+    protected $watcher;
+
     /**
      * Dynamically retrieve attributes on the entity.
      *
@@ -171,5 +173,10 @@ class ValueObject implements Mappable, ArrayAccess, Jsonable, JsonSerializable, 
             }
         }
         return $attributes;
+    }
+
+    public function setWatcher($watcher)
+    {
+        $this->watcher = $watcher;
     }
 }

--- a/src/ValueObject.php
+++ b/src/ValueObject.php
@@ -31,6 +31,13 @@ class ValueObject implements Mappable, ArrayAccess, Jsonable, JsonSerializable, 
     public function __set($key, $value)
     {
         $this->attributes[$key] = $value;
+
+        $class = class_basename($this);
+
+        if (method_exists($this->watcher, camel_case($class).'Changed'))
+        {
+            $this->watcher->{camel_case($class).'Changed'}($this);
+        }
     }
 
     /**


### PR DESCRIPTION
So I have a `Person` with a value-object `Identity`, with attributes like `name` and `surname`. The person also has an attribute called `slug`, which is based on the `name` and `surname` of `Identity`. So in order to keep `slug` up to date, I need to be able to watch `Identity` for changes. Well that's what this pull-request is for. It makes the following code possible:

    class Person extends Entity
    {
        public function identityChanged($identity)
        {
            $this->attributes['slug'] = str_slug($identity->name . ' ' . $identity->surname);
        }
    }