### PR TITLE
change __get method to also return mutators on non-existing attributes

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -24,15 +24,15 @@ class Entity extends ValueObject implements Mappable, ArrayAccess, Jsonable, Jso
 	 */
 	public function __get($key)
 	{
-		if (! array_key_exists($key, $this->attributes))
-		{
-			return null;
-		}
 		if ($this->hasGetMutator($key))
 		{
 			$method = 'get'.$this->getMutatorMethod($key);
 
 			return $this->$method($this->attributes[$key]);
+		}
+		if (! array_key_exists($key, $this->attributes))
+		{
+			return null;
 		}
 		if ($this->attributes[$key] instanceof EntityProxy)
 		{

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -28,7 +28,12 @@ class Entity extends ValueObject implements Mappable, ArrayAccess, Jsonable, Jso
 		{
 			$method = 'get'.$this->getMutatorMethod($key);
 
-			return $this->$method($this->attributes[$key]);
+			$attribute = null;
+
+			if (isset($this->attributes[$key]))
+				$attribute = $this->attributes[$key];
+
+			return $this->$method($attribute);
 		}
 		if (! array_key_exists($key, $this->attributes))
 		{

--- a/tests/AnalogueTest/App/Avatar.php
+++ b/tests/AnalogueTest/App/Avatar.php
@@ -9,4 +9,9 @@ class Avatar extends Entity {
         $this->name = $name;
         $this->user = $user;
     }
+
+    public function getPathAttribute()
+    {
+        return $this->image->path;
+    }
 }

--- a/tests/AnalogueTest/EntityTest.php
+++ b/tests/AnalogueTest/EntityTest.php
@@ -83,4 +83,14 @@ class EntityTest extends PHPUnit_Framework_TestCase {
         $rm->store($role);
         $role->toArray();
     }
+
+    public function testGetMethodsForNonExistingAttributes()
+    {
+        $user = new User('John', new Role('Admin'));
+        $avatar = new Avatar('Picture', $user);
+        $image = new Image('my-picture.jpg');
+        $avatar->image = $image;
+
+        $this->assertEquals($avatar->path, 'my-picture.jpg');
+    }
 }


### PR DESCRIPTION
This way we can use the normal getSomeAttribute() methods to do the thing you tried to explain [here](https://github.com/analogueorm/analogue/pull/58#issuecomment-141921583) in pull-request #58 .