### PR TITLE
Set default morph names

### DIFF
--- a/src/EntityMap.php
+++ b/src/EntityMap.php
@@ -809,7 +809,7 @@ class EntityMap {
 
 		$otherKey = $otherKey ?: $relatedMapper->getEntityMap()->getForeignKey();
 
-		$table = $table ?: str_plural($name);
+		$table = $table ?: $this->joiningTable(str_plural($name));
 
 		return new MorphToMany(
 			$relatedMapper, $entity, $name, $table, $foreignKey,
@@ -871,7 +871,7 @@ class EntityMap {
 		// just sort the models and join them together to get the table name.
 		$base = $this->getTable();
 
-		$related = $relatedMap->getTable();
+		$related = is_string($relatedMap) ? $relatedMap : $relatedMap->getTable();
 
 		$tables = array($related, $base);
 

--- a/src/EntityMap.php
+++ b/src/EntityMap.php
@@ -573,7 +573,7 @@ class EntityMap {
 	 * @param  string  $localKey
 	 * @return \Analogue\ORM\Relationships\MorphOne
 	 */
-	public function morphOne($entity, $related, $name, $type = null, $id = null, $localKey = null)
+	public function morphOne($entity, $related, $name = 'entity', $type = null, $id = null, $localKey = null)
 	{
 		list($type, $id) = $this->getMorphs($name, $type, $id);
 
@@ -727,7 +727,7 @@ class EntityMap {
 	 * @param  string  $localKey
 	 * @return \Analogue\ORM\Relationships\MorphMany
 	 */
-	public function morphMany($entity, $related, $name, $type = null, $id = null, $localKey = null)
+	public function morphMany($entity, $related, $name = 'entity', $type = null, $id = null, $localKey = null)
 	{
 		// Here we will gather up the morph type and ID for the relationship so that we
 		// can properly query the intermediate table of a relation. Finally, we will
@@ -796,7 +796,7 @@ class EntityMap {
 	 * @param  bool    $inverse
 	 * @return \Analogue\ORM\Relationships\MorphToMany
 	 */
-	public function morphToMany($entity, $related, $name, $table = null, $foreignKey = null, $otherKey = null, $inverse = false)
+	public function morphToMany($entity, $related, $name = 'entity', $table = null, $foreignKey = null, $otherKey = null, $inverse = false)
 	{
 		$caller = $this->getBelongsToManyCaller();
 
@@ -827,7 +827,7 @@ class EntityMap {
 	 * @param  string  $otherKey
 	 * @return \Analogue\ORM\Relationships\MorphToMany
 	 */
-	public function morphedByMany($entity, $related, $name, $table = null, $foreignKey = null, $otherKey = null)
+	public function morphedByMany($entity, $related, $name = 'entity', $table = null, $foreignKey = null, $otherKey = null)
 	{
 		$foreignKey = $foreignKey ?: $this->getForeignKey();
 


### PR DESCRIPTION
I was getting a bit tired of making up pretty morph names like "taggable" and "imageable" etc. I started to think it was a bit silly. So now I'm calling every morph "entity", so you get "entity_id" and "entity_type". And now that I've changed to this, I don't see why this couldn't be the default. I mean you almost never need to have 2 morphs on one table, so name-clashes aren't a problem. And entity is so damn generic that it works in every situation, right?

In the case of MorphToMany this means that the table-name becomes something like: entities_tags, which also more clearly shows that it represents the links between entities and tags.

What do you think?