### PR TITLE
Fixed bug in the remove function of EntityCollection

### DIFF
--- a/src/EntityCollection.php
+++ b/src/EntityCollection.php
@@ -78,9 +78,9 @@ class EntityCollection extends Collection {
 	 */
 	public function remove($entity)
 	{
-		$keyName = $this->getEntityKey($entity);
+		$key = $this->getEntityKey($entity);
 
-		return $this->pull($entity->getEntityAttribute($keyName));
+		return $this->pull($key);
 	}
 
 	/**


### PR DESCRIPTION
The remove function was retrieving the entity key, but using it as if
it only got the key name. Now it’s using the key properly.