### PR TITLE
New trait

### DIFF
--- a/src/MagicallyAccessiblePropertiesTrait.php
+++ b/src/MagicallyAccessiblePropertiesTrait.php
@@ -1,0 +1,46 @@
+<?php namespace Analogue\ORM;
+
+trait MagicallyAccessiblePropertiesTrait
+{
+    function __get($var)
+    {
+        $method = 'get' . ucfirst($var);
+
+        if (! is_callable([$this, $method])) {
+            throw new \Exception('Inaccessible property does not have getter method.');
+        }
+
+        return $this->$method();
+    }
+
+    function __set($var, $val)
+    {
+        $method = 'set' . ucfirst($var);
+
+        if (! is_callable([$this, $method])) {
+            throw new \Exception('Inaccessible property does not have setter method.');
+        }
+
+        $this->$method($val);
+    }
+
+    function offsetGet($offset)
+    {
+        return $this->$offset;
+    }
+
+    function offsetSet($offset, $value)
+    {
+        $this->$offset = $value;
+    }
+
+    function offsetExists($offset)
+    {
+        return (bool) $this->offsetGet($offset);
+    }
+
+    function offsetUnset($offset)
+    {
+        $this->$offset = null;
+    }
+}

--- a/src/MagicallyAccessiblePropertiesTrait.php
+++ b/src/MagicallyAccessiblePropertiesTrait.php
@@ -2,7 +2,7 @@
 
 trait MagicallyAccessiblePropertiesTrait
 {
-    function __get($var)
+    public function __get($var)
     {
         $method = 'get' . ucfirst($var);
 
@@ -13,7 +13,7 @@ trait MagicallyAccessiblePropertiesTrait
         return $this->$method();
     }
 
-    function __set($var, $val)
+    public function __set($var, $val)
     {
         $method = 'set' . ucfirst($var);
 
@@ -24,22 +24,22 @@ trait MagicallyAccessiblePropertiesTrait
         $this->$method($val);
     }
 
-    function offsetGet($offset)
+    public function offsetGet($offset)
     {
         return $this->$offset;
     }
 
-    function offsetSet($offset, $value)
+    public function offsetSet($offset, $value)
     {
         $this->$offset = $value;
     }
 
-    function offsetExists($offset)
+    public function offsetExists($offset)
     {
         return (bool) $this->offsetGet($offset);
     }
 
-    function offsetUnset($offset)
+    public function offsetUnset($offset)
     {
         $this->$offset = null;
     }


### PR DESCRIPTION
I believe that in the last refactoring you did made it possible to create Entity classes that don't implement the Mappable interface, is that correct? I haven't tested it yet, but that's something I like.

Now this new trait I'm proposing allows entities that have private properties, yet public getter and setter methods for those properties, to make those properties seem like their public.

So let's say you have this Entity:

``` php
<?php namespace TodoModule\Model\Entities;

use Analogue\ORM\MagicallyAccessiblePropertiesTrait;

/**
* Todo
*/
class Todo
{
    use MagicallyAccessiblePropertiesTrait;

    /**
     * @var integer
     */
    private $id;

    /**
     * @var string
     */
    private $title;

    function __construct($title)
    {
        $this->title = $title;
    }

    /**
     * Gets the value of title.
     *
     * @return string
     */
    public function getTitle()
    {
        return $this->title;
    }

    /**
     * Sets the value of title.
     *
     * @param string $title the title
     *
     * @return self
     */
    public function setTitle($title)
    {
        $this->title = $title;

        return $this;
    }
}
```

Now since `Todo` uses the trait and the title has getters and setters, one can access the title as if it were public, like this:

``` php
$todo = new Todo('Wash the dishes');
echo $todo->title;
```

However, the `id` property is still protected, because it has no getters nor setters. In a template this syntax is just easier on the eyes than `$todo->getTitle();`. Now if a developer would wish to use their entity as if it were an array, that's also possible with this trait. The developer only has to make their entity implement `ArrayAccess` and then he can access the title of the todo by using `$todo['title']`.

What do you think?
