### PR TITLE
Fixed issue in EntityProxy

### DIFF
--- a/src/System/Proxies/EntityProxy.php
+++ b/src/System/Proxies/EntityProxy.php
@@ -79,6 +79,6 @@ class EntityProxy extends Proxy
             $this->loadOnce();
         }
 
-        return call_user_func_array([$this->loadedCollection, $method], $parameters);
+        return call_user_func_array([$this->entity, $method], $parameters);
     }
 }


### PR DESCRIPTION
EntityProxy was calling `$this->loadedCollection` instead of `$this->entity` in the `__call` method

(Sorry, moved it to a separate branch so it didn't get mixed up with other pull requests)