### PR TITLE
Add support of traversables

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -114,4 +114,33 @@ class Entity extends ValueObject
         }
         return $attributes;
     }
+
+    /**
+     * Create entity with arbitrary arguments
+     *
+     * @param array|string $argumentsOrPrimaryKey
+     * @return Entity
+     * @throws MappingException
+     * @throws \InvalidArgumentException
+     */
+    public static function mock($argumentsOrPrimaryKey)
+    {
+        if (!is_array($argumentsOrPrimaryKey)) {
+            $primaryKey = Manager::getInstance()
+                ->mapper(static::class)
+                ->getEntityMap()
+                ->getKeyName();
+
+            $argumentsOrPrimaryKey = [$primaryKey => $argumentsOrPrimaryKey];
+        }
+
+        $instance = (new \ReflectionClass(static::class))
+            ->newInstanceWithoutConstructor();
+
+        foreach ($argumentsOrPrimaryKey as $key => $value) {
+            $instance->$key = $value;
+        }
+
+        return $instance;
+    }
 }

--- a/src/System/Manager.php
+++ b/src/System/Manager.php
@@ -113,7 +113,7 @@ class Manager
     /**
      * Create a mapper for a given entity
      *
-     * @param  \Analogue\ORM\Mappable|string|array|Collection $entity
+     * @param  \Analogue\ORM\Mappable|string|array|\Traversable $entity
      * @param  mixed $entityMap
      * @throws MappingException
      * @throws \InvalidArgumentException
@@ -125,22 +125,23 @@ class Manager
             throw new MappingException('Tried to instantiate mapper on wrapped Entity');
         }
 
-        // Implementation Mapper isArrayOrCollection method
-        if (is_array($entity) || $entity instanceof Collection) {
-            if (!count($entity)) {
-                throw new \InvalidArgumentException('Length of Entity collection must be greater than 0');
-            }
-            $entity = $entity[0];
+        switch (true) {
+            case Support::isTraversable($entity):
+                if (!count($entity)) {
+                    throw new \InvalidArgumentException('Length of Entity collection must be greater than 0');
+                }
 
+                $entity = $entity[0];
+                break;
 
-        } elseif (is_object($entity)) {
-            $entity = get_class($entity);
+            case is_object($entity):
+                $entity = get_class($entity);
+                break;
 
-
-        } elseif (!is_string($entity)) {
-            throw new \InvalidArgumentException('Invalid mapper Entity type');
+            case !is_string($entity):
+                throw new \InvalidArgumentException('Invalid mapper Entity type');
+                break;
         }
-
 
         $entity = $this->getInverseMorphMap($entity);
 

--- a/src/System/Manager.php
+++ b/src/System/Manager.php
@@ -134,7 +134,10 @@ class Manager
                     throw new \InvalidArgumentException('Length of Entity collection must be greater than 0');
                 }
 
-                $entity = $entity[0];
+                $entity = ($entity instanceof \Iterator || $entity instanceof \IteratorAggregate)
+                    ? $entity->current()
+                    : current($entity);
+
                 break;
 
             case is_object($entity):

--- a/src/System/Manager.php
+++ b/src/System/Manager.php
@@ -16,6 +16,13 @@ use Analogue\ORM\Drivers\Manager as DriverManager;
 class Manager
 {
     /**
+     * Manager instance
+     *
+     * @var Manager
+     */
+    protected static $instance;
+
+    /**
      * Driver Manager
      *
      * @var \Analogue\ORM\Drivers\Manager
@@ -63,13 +70,6 @@ class Manager
     protected $eventDispatcher;
 
     /**
-     * Manager instance
-     *
-     * @var Manager
-     */
-    protected static $instance;
-
-    /**
      * Available Analogue Events
      *
      * @var array
@@ -89,7 +89,7 @@ class Manager
 
     /**
      * @param \Analogue\ORM\Drivers\Manager $driverManager
-     * @param Dispatcher $event
+     * @param Dispatcher                    $event
      */
     public function __construct(DriverManager $driverManager, Dispatcher $event)
     {
@@ -101,20 +101,23 @@ class Manager
     }
 
     /**
-     * Return the Driver Manager's instance
+     * Create a mapper for a given entity (static alias)
      *
-     * @return \Analogue\ORM\Drivers\Manager
+     * @param  \Analogue\ORM\Mappable|string $entity
+     * @param  null|EntityMap                $entityMap
+     * @throws MappingException
+     * @return Mapper
      */
-    public function getDriverManager()
+    public static function getMapper($entity, $entityMap = null)
     {
-        return $this->drivers;
+        return static::$instance->mapper($entity, $entityMap);
     }
 
     /**
      * Create a mapper for a given entity
      *
      * @param  \Analogue\ORM\Mappable|string|array|\Traversable $entity
-     * @param  mixed $entityMap
+     * @param  mixed                                            $entityMap
      * @throws MappingException
      * @throws \InvalidArgumentException
      * @return Mapper
@@ -154,6 +157,15 @@ class Manager
     }
 
     /**
+     * @param string $key
+     * @return string
+     */
+    public function getInverseMorphMap($key)
+    {
+        return array_key_exists($key, $this->morphMap) ? $this->morphMap[$key] : $key;
+    }
+
+    /**
      * Build a new Mapper instance for a given Entity
      *
      * @param  string $entity
@@ -181,45 +193,23 @@ class Manager
         // the mapper is now instantiated & registered within the manager.
 
         $mapper->getEntityMap()->boot();
-        
+
         return $mapper;
     }
 
     /**
-     * Create a mapper for a given entity (static alias)
+     * Check if the entity is already registered
      *
-     * @param  \Analogue\ORM\Mappable|string $entity
-     * @param  null|EntityMap                $entityMap
-     * @throws MappingException
-     * @return Mapper
+     * @param  string|object $entity
+     * @return boolean
      */
-    public static function getMapper($entity, $entityMap = null)
-    {
-        return static::$instance->mapper($entity, $entityMap);
-    }
-
-    /**
-     * Get the Repository instance for the given Entity
-     *
-     * @param  \Analogue\ORM\Mappable|string $entity
-     * @throws \InvalidArgumentException
-     * @throws MappingException
-     * @return \Analogue\ORM\Repository
-     */
-    public function repository($entity)
+    public function isRegisteredEntity($entity)
     {
         if (!is_string($entity)) {
             $entity = get_class($entity);
         }
 
-        // First we check if the repository is not already created.
-        if (array_key_exists($entity, $this->repositories)) {
-            return $this->repositories[$entity];
-        }
-
-        $this->repositories[$entity] = new Repository($this->mapper($entity));
-        
-        return $this->repositories[$entity];
+        return array_key_exists($entity, $this->entityClasses);
     }
 
     /**
@@ -267,7 +257,7 @@ class Manager
     /**
      * Get the entity map instance for a custom entity
      *
-     * @param  string   $entity
+     * @param  string $entity
      * @return \Analogue\ORM\Mappable
      */
     protected function getEntityMapInstanceFor($entity)
@@ -279,7 +269,7 @@ class Manager
             // Generate an EntityMap object
             $map = $this->getNewEntityMap();
         }
-        
+
         return $map;
     }
 
@@ -294,28 +284,47 @@ class Manager
     }
 
     /**
-     * Register a Value Object
+     * Return the Singleton instance of the manager
      *
-     * @param  string $valueObject
-     * @param  string $valueMap
-     * @throws MappingException
-     * @return void
+     * @return Manager
      */
-    public function registerValueObject($valueObject, $valueMap = null)
+    public static function getInstance()
     {
-        if (!is_string($valueObject)) {
-            $valueObject = get_class($valueObject);
+        return static::$instance;
+    }
+
+    /**
+     * Return the Driver Manager's instance
+     *
+     * @return \Analogue\ORM\Drivers\Manager
+     */
+    public function getDriverManager()
+    {
+        return $this->drivers;
+    }
+
+    /**
+     * Get the Repository instance for the given Entity
+     *
+     * @param  \Analogue\ORM\Mappable|string $entity
+     * @throws \InvalidArgumentException
+     * @throws MappingException
+     * @return \Analogue\ORM\Repository
+     */
+    public function repository($entity)
+    {
+        if (!is_string($entity)) {
+            $entity = get_class($entity);
         }
 
-        if (is_null($valueMap)) {
-            $valueMap = $valueObject . 'Map';
+        // First we check if the repository is not already created.
+        if (array_key_exists($entity, $this->repositories)) {
+            return $this->repositories[$entity];
         }
 
-        if (!class_exists($valueMap)) {
-            throw new MappingException("$valueMap doesn't exists");
-        }
+        $this->repositories[$entity] = new Repository($this->mapper($entity));
 
-        $this->valueClasses[$valueObject] = $valueMap;
+        return $this->repositories[$entity];
     }
 
     /**
@@ -357,6 +366,31 @@ class Manager
     }
 
     /**
+     * Register a Value Object
+     *
+     * @param  string $valueObject
+     * @param  string $valueMap
+     * @throws MappingException
+     * @return void
+     */
+    public function registerValueObject($valueObject, $valueMap = null)
+    {
+        if (!is_string($valueObject)) {
+            $valueObject = get_class($valueObject);
+        }
+
+        if (is_null($valueMap)) {
+            $valueMap = $valueObject . 'Map';
+        }
+
+        if (!class_exists($valueMap)) {
+            throw new MappingException("$valueMap doesn't exists");
+        }
+
+        $this->valueClasses[$valueObject] = $valueMap;
+    }
+
+    /**
      * Instantiate a new Value Object instance
      *
      * @param  string $valueObject
@@ -365,6 +399,7 @@ class Manager
     public function getValueObjectInstance($valueObject)
     {
         $prototype = unserialize(sprintf('O:%d:"%s":0:{}', strlen($valueObject), $valueObject));
+
         return $prototype;
     }
 
@@ -384,25 +419,10 @@ class Manager
     }
 
     /**
-     * Check if the entity is already registered
-     *
-     * @param  string|object $entity
-     * @return boolean
-     */
-    public function isRegisteredEntity($entity)
-    {
-        if (!is_string($entity)) {
-            $entity = get_class($entity);
-        }
-
-        return array_key_exists($entity, $this->entityClasses);
-    }
-
-    /**
      * Register event listeners that will be fired regardless the type
      * of the entity.
      *
-     * @param  string $event
+     * @param  string   $event
      * @param  \Closure $callback
      * @throws \Exception
      * @return void
@@ -463,30 +483,25 @@ class Manager
         return $this->mapper($entity)->globalQuery();
     }
 
+    /**
+     * @param array $morphMap
+     * @return $this
+     */
     public function morphMap(array $morphMap)
     {
         $this->morphMap = $morphMap;
+
         return $this;
     }
 
+    /**
+     * @param string $class
+     * @return mixed
+     */
     public function getMorphMap($class)
     {
         $key = array_search($class, $this->morphMap);
-        return $key !== false ? $key : $class;
-    }
 
-    public function getInverseMorphMap($key)
-    {
-        return array_key_exists($key, $this->morphMap) ? $this->morphMap[$key] : $key;
-    }
-    
-    /**
-     * Return the Singleton instance of the manager
-     *
-     * @return Manager
-     */
-    public static function getInstance()
-    {
-        return static::$instance;
+        return $key !== false ? $key : $class;
     }
 }

--- a/src/System/Mapper.php
+++ b/src/System/Mapper.php
@@ -2,16 +2,16 @@
 
 namespace Analogue\ORM\System;
 
-use Analogue\ORM\System\Wrappers\Wrapper;
-use InvalidArgumentException;
-use Analogue\ORM\Mappable;
-use Analogue\ORM\EntityMap;
-use Analogue\ORM\Commands\Store;
 use Analogue\ORM\Commands\Delete;
+use Analogue\ORM\Commands\Store;
+use Analogue\ORM\Drivers\DBAdapter;
+use Analogue\ORM\EntityMap;
+use Analogue\ORM\Exceptions\MappingException;
+use Analogue\ORM\Mappable;
+use Analogue\ORM\System\Wrappers\Wrapper;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Collection;
-use Analogue\ORM\Drivers\DBAdapter;
-use Analogue\ORM\Exceptions\MappingException;
+use InvalidArgumentException;
 
 /**
  * The mapper provide all the interactions with the database layer
@@ -73,10 +73,10 @@ class Mapper
     protected $customCommands = [];
 
     /**
-     * @param EntityMap  $entityMap
-     * @param DBAdapter  $adapter
+     * @param EntityMap $entityMap
+     * @param DBAdapter $adapter
      * @param Dispatcher $dispatcher
-     * @param Manager    $manager
+     * @param Manager $manager
      */
     public function __construct(EntityMap $entityMap, DBAdapter $adapter, Dispatcher $dispatcher, Manager $manager)
     {
@@ -94,14 +94,14 @@ class Mapper
     /**
      * Persist an entity or an entity collection into the database
      *
-     * @param  Mappable|Collection $entity
+     * @param  Mappable|\Traversable|array $entity
      * @throws \InvalidArgumentException
      * @throws MappingException
-     * @return Mappable|Collection
+     * @return Mappable|\Traversable|array
      */
     public function store($entity)
     {
-        if ($this->isArrayOrCollection($entity)) {
+        if (Support::isTraversable($entity)) {
             return $this->storeCollection($entity);
         } else {
             return $this->storeEntity($entity);
@@ -109,14 +109,24 @@ class Mapper
     }
 
     /**
-     * Return true if an object is an array or collection
+     * Store an entity collection inside a single DB Transaction
      *
-     * @param  mixed $argument
-     * @return boolean
+     * @param  \Traversable|array $entities
+     * @throws \InvalidArgumentException
+     * @throws MappingException
+     * @return \Traversable|array
      */
-    protected function isArrayOrCollection($argument)
+    protected function storeCollection($entities)
     {
-        return $argument instanceof Collection || is_array($argument);
+        $this->adapter->beginTransaction();
+
+        foreach ($entities as $entity) {
+            $this->storeEntity($entity);
+        }
+
+        $this->adapter->commit();
+
+        return $entities;
     }
 
     /**
@@ -137,6 +147,22 @@ class Mapper
     }
 
     /**
+     * Check that the entity correspond to the current mapper.
+     *
+     * @param  mixed $entity
+     * @throws InvalidArgumentException
+     * @return void
+     */
+    protected function checkEntityType($entity)
+    {
+        if (get_class($entity) != $this->entityMap->getClass()) {
+            $expected = $this->entityMap->getClass();
+            $actual = get_class($entity);
+            throw new InvalidArgumentException("Expected : $expected, got $actual.");
+        }
+    }
+
+    /**
      * Convert an entity into an aggregate root
      *
      * @param  mixed $entity
@@ -149,41 +175,51 @@ class Mapper
     }
 
     /**
-     * Store an entity collection inside a single DB Transaction
+     * Get a the Underlying QueryAdapter.
      *
-     * @param  Collection|array $entities
-     * @throws \InvalidArgumentException
-     * @throws MappingException
-     * @return Collection
+     * @return \Analogue\ORM\Drivers\QueryAdapter
      */
-    protected function storeCollection($entities)
+    public function newQueryBuilder()
     {
-        $this->adapter->beginTransaction();
-
-        foreach ($entities as $entity) {
-            $this->storeEntity($entity);
-        }
-
-        $this->adapter->commit();
-
-        return $entities;
+        return $this->adapter->getQuery();
     }
 
     /**
      * Delete an entity or an entity collection from the database
      *
-     * @param  mixed|Collection
+     * @param  Mappable|\Traversable|array
      * @throws MappingException
      * @throws \InvalidArgumentException
-     * @return Collection|void
+     * @return \Traversable|array
      */
     public function delete($entity)
     {
-        if ($this->isArrayOrCollection($entity)) {
+        if (Support::isTraversable($entity)) {
             return $this->deleteCollection($entity);
         } else {
             $this->deleteEntity($entity);
         }
+    }
+
+    /**
+     * Delete an Entity Collection inside a single db transaction
+     *
+     * @param  \Traversable|array $entities
+     * @throws \InvalidArgumentException
+     * @throws MappingException
+     * @return \Traversable|array
+     */
+    protected function deleteCollection($entities)
+    {
+        $this->adapter->beginTransaction();
+
+        foreach ($entities as $entity) {
+            $this->deleteEntity($entity);
+        }
+
+        $this->adapter->commit();
+
+        return $entities;
     }
 
     /**
@@ -201,27 +237,6 @@ class Mapper
         $delete = new Delete($this->aggregate($entity), $this->newQueryBuilder());
 
         $delete->execute();
-    }
-
-    /**
-     * Delete an Entity Collection inside a single db transaction
-     *
-     * @param  Collection|array $entities
-     * @throws \InvalidArgumentException
-     * @throws MappingException
-     * @return Collection
-     */
-    protected function deleteCollection($entities)
-    {
-        $this->adapter->beginTransaction();
-
-        foreach ($entities as $entity) {
-            $this->deleteEntity($entity);
-        }
-
-        $this->adapter->commit();
-        
-        return $entities;
     }
 
     /**
@@ -247,9 +262,9 @@ class Mapper
     /**
      * Fire the given event for the entity
      *
-     * @param  string               $event
+     * @param  string $event
      * @param  \Analogue\ORM\Entity $entity
-     * @param  bool                 $halt
+     * @param  bool $halt
      * @throws InvalidArgumentException
      * @return mixed
      */
@@ -269,7 +284,7 @@ class Mapper
     /**
      * Register an entity event with the dispatcher.
      *
-     * @param  string   $event
+     * @param  string $event
      * @param  \Closure $callback
      * @return void
      */
@@ -316,13 +331,28 @@ class Mapper
     }
 
     /**
-     * Get the global scopes for this class instance.
+     * Get a new query instance without a given scope.
      *
-     * @return \Analogue\ORM\System\ScopeInterface
+     * @param  \Analogue\ORM\System\ScopeInterface $scope
+     * @return \Analogue\ORM\System\Query
      */
-    public function getGlobalScopes()
+    public function newQueryWithoutScope($scope)
     {
-        return $this->globalScopes;
+        $this->getGlobalScope($scope)->remove($query = $this->getQuery(), $this);
+
+        return $query;
+    }
+
+    /**
+     * Get the Analogue Query Builder for this instance
+     *
+     * @return \Analogue\ORM\System\Query
+     */
+    public function getQuery()
+    {
+        $query = new Query($this, $this->adapter);
+
+        return $this->applyGlobalScopes($query);
     }
 
     /**
@@ -341,41 +371,13 @@ class Mapper
     }
 
     /**
-     * Remove all of the global scopes from an Analogue Query builder.
+     * Get the global scopes for this class instance.
      *
-     * @param Query $query
-     * @return \Analogue\ORM\System\Query
+     * @return \Analogue\ORM\System\ScopeInterface
      */
-    public function removeGlobalScopes($query)
+    public function getGlobalScopes()
     {
-        foreach ($this->getGlobalScopes() as $scope) {
-            $scope->remove($query, $this);
-        }
-
-        return $query;
-    }
-
-    /**
-     * Get a new query instance without a given scope.
-     *
-     * @param  \Analogue\ORM\System\ScopeInterface $scope
-     * @return \Analogue\ORM\System\Query
-     */
-    public function newQueryWithoutScope($scope)
-    {
-        $this->getGlobalScope($scope)->remove($query = $this->getQuery(), $this);
-
-        return $query;
-    }
-
-    /**
-     * Get a new query builder that doesn't have any global scopes.
-     *
-     * @return Query
-     */
-    public function newQueryWithoutScopes()
-    {
-        return $this->removeGlobalScopes($this->getQuery());
+        return $this->globalScopes;
     }
 
     /**
@@ -388,82 +390,6 @@ class Mapper
         $name = lcfirst(class_basename($command));
 
         $this->customCommands[$name] = $command;
-    }
-
-    /**
-     * Execute a custom command on an Entity
-     *
-     * @param  string                 $command
-     * @param  mixed|Collection|array $entity
-     * @throws \InvalidArgumentException
-     * @throws MappingException
-     * @return mixed
-     */
-    public function executeCustomCommand($command, $entity)
-    {
-        $commandClass = $this->customCommands[$command];
-
-        if ($this->isArrayOrCollection($entity)) {
-            foreach ($entity as $instance) {
-                $this->executeSingleCustomCommand($commandClass, $instance);
-            }
-        } else {
-            return $this->executeSingleCustomCommand($commandClass, $entity);
-        }
-    }
-
-    /**
-     * Execute a single command instance
-     *
-     * @param  string $commandClass
-     * @param  mixed  $entity
-     * @throws \InvalidArgumentException
-     * @throws MappingException
-     * @return mixed
-     */
-    protected function executeSingleCustomCommand($commandClass, $entity)
-    {
-        $this->checkEntityType($entity);
-
-        $instance = new $commandClass($this->aggregate($entity), $this->newQueryBuilder());
-
-        return $instance->execute();
-    }
-
-    /**
-     * Check that the entity correspond to the current mapper.
-     *
-     * @param  mixed $entity
-     * @throws InvalidArgumentException
-     * @return void
-     */
-    protected function checkEntityType($entity)
-    {
-        if (get_class($entity) != $this->entityMap->getClass()) {
-            $expected = $this->entityMap->getClass();
-            $actual = get_class($entity);
-            throw new InvalidArgumentException("Expected : $expected, got $actual.");
-        }
-    }
-
-    /**
-     * Get all the custom commands registered on this mapper
-     *
-     * @return array
-     */
-    public function getCustomCommands()
-    {
-        return array_keys($this->customCommands);
-    }
-
-    /**
-     * Check if this mapper supports this command
-     * @param  string $command
-     * @return boolean
-     */
-    public function hasCustomCommand($command)
-    {
-        return in_array($command, $this->getCustomCommands());
     }
 
     /**
@@ -505,29 +431,8 @@ class Mapper
         }
 
         $prototype = unserialize(sprintf('O:%d:"%s":0:{}', strlen($className), $className));
-        return $prototype;
-    }
-    
-    /**
-     * Get the Analogue Query Builder for this instance
-     *
-     * @return \Analogue\ORM\System\Query
-     */
-    public function getQuery()
-    {
-        $query = new Query($this, $this->adapter);
 
-        return $this->applyGlobalScopes($query);
-    }
-    
-    /**
-     * Get the Analogue Query Builder for this instance
-     *
-     * @return \Analogue\ORM\System\Query
-     */
-    public function query()
-    {
-        return $this->getQuery();
+        return $prototype;
     }
 
     /**
@@ -541,13 +446,28 @@ class Mapper
     }
 
     /**
-     * Get a the Underlying QueryAdapter.
+     * Get a new query builder that doesn't have any global scopes.
      *
-     * @return \Analogue\ORM\Drivers\QueryAdapter
+     * @return Query
      */
-    public function newQueryBuilder()
+    public function newQueryWithoutScopes()
     {
-        return $this->adapter->getQuery();
+        return $this->removeGlobalScopes($this->getQuery());
+    }
+
+    /**
+     * Remove all of the global scopes from an Analogue Query builder.
+     *
+     * @param Query $query
+     * @return \Analogue\ORM\System\Query
+     */
+    public function removeGlobalScopes($query)
+    {
+        foreach ($this->getGlobalScopes() as $scope) {
+            $scope->remove($query, $this);
+        }
+
+        return $query;
     }
 
     /**
@@ -564,7 +484,7 @@ class Mapper
      * Dynamically handle calls to custom commands, or Redirects to query()
      *
      * @param  string $method
-     * @param  array  $parameters
+     * @param  array $parameters
      * @throws \Exception
      * @return mixed
      */
@@ -575,10 +495,81 @@ class Mapper
             if (count($parameters) == 0) {
                 throw new \Exception("$method must at least have 1 argument");
             }
+
             return $this->executeCustomCommand($method, $parameters[0]);
         }
 
         // Redirect call on a new query instance
         return call_user_func_array([$this->query(), $method], $parameters);
+    }
+
+    /**
+     * Check if this mapper supports this command
+     * @param  string $command
+     * @return boolean
+     */
+    public function hasCustomCommand($command)
+    {
+        return in_array($command, $this->getCustomCommands());
+    }
+
+    /**
+     * Get all the custom commands registered on this mapper
+     *
+     * @return array
+     */
+    public function getCustomCommands()
+    {
+        return array_keys($this->customCommands);
+    }
+
+    /**
+     * Execute a custom command on an Entity
+     *
+     * @param  string $command
+     * @param  mixed|Collection|array $entity
+     * @throws \InvalidArgumentException
+     * @throws MappingException
+     * @return mixed
+     */
+    public function executeCustomCommand($command, $entity)
+    {
+        $commandClass = $this->customCommands[$command];
+
+        if (Support::isTraversable($entity)) {
+            foreach ($entity as $instance) {
+                $this->executeSingleCustomCommand($commandClass, $instance);
+            }
+        } else {
+            return $this->executeSingleCustomCommand($commandClass, $entity);
+        }
+    }
+
+    /**
+     * Execute a single command instance
+     *
+     * @param  string $commandClass
+     * @param  mixed $entity
+     * @throws \InvalidArgumentException
+     * @throws MappingException
+     * @return mixed
+     */
+    protected function executeSingleCustomCommand($commandClass, $entity)
+    {
+        $this->checkEntityType($entity);
+
+        $instance = new $commandClass($this->aggregate($entity), $this->newQueryBuilder());
+
+        return $instance->execute();
+    }
+
+    /**
+     * Get the Analogue Query Builder for this instance
+     *
+     * @return \Analogue\ORM\System\Query
+     */
+    public function query()
+    {
+        return $this->getQuery();
     }
 }

--- a/src/System/Support.php
+++ b/src/System/Support.php
@@ -1,0 +1,20 @@
+<?php
+namespace Analogue\ORM\System;
+
+/**
+ * Class Support
+ * @package Analogue\ORM\System
+ */
+class Support
+{
+    /**
+     * Return true if an object is an array or iterator
+     *
+     * @param  mixed $argument
+     * @return boolean
+     */
+    public static function isTraversable($argument)
+    {
+        return $argument instanceof \Traversable || is_array($argument);
+    }
+}


### PR DESCRIPTION
In this commit:

- Change `\Illuminate\Support\Collection` to `\Traversable`

- Move `Analogue\ORM\System\Mapper::isArrayOrCollection` to `Analogue\ORM\System\Support::isTraversable` helper

- Update methods and properties of Mapper to alphabetic order (a little codestyle improvement :3 ).

What are the advantages it gives? Example:

```php
$fackerFactory = function() {
  foreach ([1, 2, 3] as $i) {
      $args = json_decode(file_get_contents('...?page=' . $i));
      yield new MyEntity($args);
  }
};

$analogue->store($fackerFactory());
```

Briefly: Add `\Generator`, `\Iterator`, `\IteratorAggregate` and etc supporting in `->store`, `->delete` methods of `Manager` and `Mapper` classes.