### PR TITLE
Add support of traversables

### DIFF
--- a/src/System/Support.php
+++ b/src/System/Support.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Analogue\ORM\System;
+
+/**
+ * This class contains a helper methods
+ */
+class Support
+{
+    /**
+     * Return true if an object is an array or iterator
+     *
+     * @param  mixed $argument
+     * @return boolean
+     */
+    public static function isTraversable($argument)
+    {
+        return $argument instanceof \Traversable || is_array($argument);
+    }
+}


### PR DESCRIPTION
In this commit:

- Change `\Illuminate\Support\Collection` to `\Traversable`

- Move `Analogue\ORM\System\Mapper::isArrayOrCollection` to `Analogue\ORM\System\Support::isTraversable` helper

- Update methods and properties of Mapper to alphabetic order (a little codestyle improvement :3 ).

What are the advantages it gives? Example:

```php
$fackerFactory = function() {
  foreach ([1, 2, 3] as $i) {
      $args = json_decode(file_get_contents('...?page=' . $i));
      yield new MyEntity($args);
  }
};

$analogue->store($fackerFactory());
```

Briefly: Add `\Generator`, `\Iterator`, `\IteratorAggregate` and etc supporting in `->store`, `->delete` methods of `Manager` and `Mapper` classes.