### PR TITLE
Add mock method to ValueObject

### DIFF
--- a/src/ValueObject.php
+++ b/src/ValueObject.php
@@ -165,4 +165,37 @@ class ValueObject implements Mappable, ArrayAccess, Jsonable, JsonSerializable, 
         }
         return $attributes;
     }
+
+    /**
+     * Create entity with arbitrary arguments
+     *
+     * @param array|string $argumentsOrPrimaryKey
+     * @return $this
+     * @throws MappingException
+     * @throws \InvalidArgumentException
+     */
+    public static function mock($argumentsOrPrimaryKey)
+    {
+        $arguments = $argumentsOrPrimaryKey;
+
+        if (!is_array($argumentsOrPrimaryKey)) {
+            $primaryKey = Manager::getInstance()
+                ->mapper(static::class)
+                ->getEntityMap()
+                ->getKeyName();
+
+            $arguments = [$primaryKey => $argumentsOrPrimaryKey];
+        }
+
+        $instance = (new \ReflectionClass(static::class))
+            ->newInstanceWithoutConstructor();
+
+        $arguments = $instance->attributesToArray($arguments);
+
+        foreach ($arguments as $key => $value) {
+            $instance->$key = $value;
+        }
+
+        return $instance;
+    }
 }


### PR DESCRIPTION
This commit add `mock` method to ValueObject (and Entity as a result). 

### Usage

Default method for store objects:

```php
$user = new User('login', 'password');

$analogue->store($user);
```

But this object can not be deleting through analogue manager because model has no primary key value.

```php
$user = new User('login', 'password');

$analogue->delete($user); // Error: Primary key N can not be null
```

This commit add alternative method for entities creating and deleting through manager:
```php
$user = User::mock(42); // User { id => 42 }

$analogue->delete($user);
```

and can be used with custom PK's:
```php
class UserMap extends EntityMap {
    protected $primaryKey = 'uuid';
}

$analogue->mapper(User::class, UserMap::class)
    ->registerEvent('creating', function(Entity $entity) {
        if (!$entity->uuid) {
            $entity->uuid = Uuid::v4(); // Uuid creator example
        }
    });

$analogue->delete(User::mock('de305d54-75b4-431b-adb2-eb6b9e546014'));
```