### PR TITLE
Fix some issues in PlainObjectWrapper and re-enable PlainObjectTest

### DIFF
--- a/src/System/Wrappers/PlainObjectWrapper.php
+++ b/src/System/Wrappers/PlainObjectWrapper.php
@@ -29,9 +29,9 @@ class PlainObjectWrapper extends Wrapper
     {
         $this->reflection = new ReflectionClass($popoEntity);
 
-        $this->attributeList = $this->getAttributeList();
-
         parent::__construct($popoEntity, $entityMap);
+
+        $this->attributeList = $this->getAttributeList();
     }
 
     /**
@@ -197,7 +197,7 @@ class PlainObjectWrapper extends Wrapper
          */
     public function hasAttribute($key)
     {
-        if (array_key_exists($key, $$this->attributeList)) {
+        if (array_key_exists($key, $this->attributeList)) {
             return true;
         } else {
             return false;

--- a/tests/AnalogueTest/App/Popo.php
+++ b/tests/AnalogueTest/App/Popo.php
@@ -10,6 +10,8 @@ class Popo
 
     protected $user;
 
+    protected $user_id;
+
     public function __construct($name)
     {
         $this->name = $name;

--- a/tests/AnalogueTest/PlainObjectTest.php
+++ b/tests/AnalogueTest/PlainObjectTest.php
@@ -8,8 +8,7 @@ class PlainObjectTest extends PHPUnit_Framework_TestCase
 {
     public function testPopoStore()
     {
-
-        /*$popo = new Popo('popo1');
+        $popo = new Popo('popo1');
 
         $mapper = get_mapper($popo);
 
@@ -20,12 +19,12 @@ class PlainObjectTest extends PHPUnit_Framework_TestCase
 
         $mapper->store($popo);
 
-        $this->assertGreaterThan(0, $popo->getId());*/
+        $this->assertGreaterThan(0, $popo->getId());
     }
 
     public function testPopoSingleRelationship()
     {
-        /*$popo = new Popo('popo2');
+        $popo = new Popo('popo2');
 
         $mapper = get_mapper($popo);
 
@@ -33,6 +32,6 @@ class PlainObjectTest extends PHPUnit_Framework_TestCase
 
         $popo->setUser($user);
 
-        $mapper->store($popo);*/
+        $mapper->store($popo);
     }
 }


### PR DESCRIPTION
Hi, I used PlainObjectWrapper for POPO Entity. 
But I got an following error.

```
PHP Fatal error:  Call to a member function getCompiledAttributes() on null in (snip)/System/Wrappers/PlainObjectWrapper.php on line 44

Fatal error: Call to a member function getCompiledAttributes() on null in (snip)/System/Wrappers/PlainObjectWrapper.php on line 44
```

This PR resolve the issue and re-enable PlainObjectTest.