### PR TITLE
fixed an issue with morph types not being added as a foreign key

### DIFF
--- a/src/Relationships/MorphTo.php
+++ b/src/Relationships/MorphTo.php
@@ -205,7 +205,10 @@ class MorphTo extends BelongsTo
 
             $relatedKey = $this->relatedMap->getKeyName();
 
-            return [$foreignKey => $wrapper->getEntityAttribute($relatedKey)];
+            return [
+                $foreignKey => $wrapper->getEntityAttribute($relatedKey),
+                $this->morphType => $wrapper->getMap()->getMorphClass(),
+            ];
         } else {
             return [$foreignKey => null];
         }

--- a/src/System/Wrappers/Wrapper.php
+++ b/src/System/Wrappers/Wrapper.php
@@ -57,6 +57,16 @@ abstract class Wrapper implements InternallyMappable
     }
 
     /**
+     * Returns the wrapped entity's map
+     *
+     * @return mixed
+     */
+    public function getMap()
+    {
+        return $this->entityMap;
+    }
+
+    /**
      * Set the lazyloading proxies on the wrapped entity objet
      *
      * @return void


### PR DESCRIPTION
When adding a MorphTo to a database only the morph id column was being
set. Update MorphTo to add the type column as well.