### PR TITLE
fixed issue with MorphTo's `associate` method

### DIFF
--- a/src/Relationships/MorphTo.php
+++ b/src/Relationships/MorphTo.php
@@ -186,7 +186,7 @@ class MorphTo extends BelongsTo
         //
         // Instead, we'll just add the object to the Entity's attribute
 
-        $this->parent->setEntityAttribute($this->relation, $entity);
+        $this->parent->setEntityAttribute($this->relation, $entity->getEntityObject());
     }
 
     /**


### PR DESCRIPTION
MorphTo's `associate` method was setting the Aggregate object as the
entity attribute instead of the entity object itself