### PR TITLE
added required abstract sync method

### DIFF
--- a/src/Relationships/HasManyThrough.php
+++ b/src/Relationships/HasManyThrough.php
@@ -308,4 +308,16 @@ class HasManyThrough extends Relationship
     {
         return $this->farParentMap->getQualifiedKeyName();
     }
+
+    /**
+     * Run synchronization content if needed by the
+     * relation type.
+     *
+     * @param  array $actualContent
+     * @return void
+     */
+    public function sync(array $entities)
+    {
+        // N/A
+    }
 }


### PR DESCRIPTION
The `HasManyThrough` relationship was missing a required abstract method called `sync`. I don't know what it's meant to do, but my PHP auto-completer kept complaining about it.