### PR TITLE
fixed issue with entity property mutators studly case

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -88,7 +88,8 @@ class Entity extends ValueObject
      */
     protected function getMutatorMethod($key)
     {
-        return ucfirst($key) . 'Attribute';
+        $key = ucwords(str_replace(['-', '_'], ' ', $key));
+        return str_replace(' ', '', $key) . "Attribute";
     }
 
     /**
@@ -101,7 +102,7 @@ class Entity extends ValueObject
         // First, call the trait method before filtering
         // with Entity specific methods
         $attributes = $this->attributesToArray($this->attributes);
-        
+
         foreach ($this->attributes as $key => $attribute) {
             if (in_array($key, $this->hidden)) {
                 unset($attributes[$key]);


### PR DESCRIPTION
Currently a property of `alternate_name` requires a mutator called `getAlternate_NameAttribute` whereas one would expect it to be `getAlternateNameAttribute`.

Technically this will break backwards compatibility. But I think it's probably the correct behaviour.