### PR TITLE
Laravel 5.3 query builder returns a Collection instead of an array

### DIFF
--- a/src/System/EntityBuilder.php
+++ b/src/System/EntityBuilder.php
@@ -70,7 +70,7 @@ class EntityBuilder
      * @param  array $results
      * @return array
      */
-    public function build(array $results)
+    public function build($results)
     {
         $entities = [];
 


### PR DESCRIPTION
Works if we remove the type check
