### PR TITLE
5.3 dev

### DIFF
--- a/src/EntityCollection.php
+++ b/src/EntityCollection.php
@@ -43,7 +43,7 @@ class EntityCollection extends Collection
         }
 
         return array_first($this->items, function ($entity, $itemKey) use ($key) {
-            
+
             return $this->getEntityKey($entity) == $key;
         }, $default);
     }
@@ -383,10 +383,11 @@ class EntityCollection extends Collection
      * Return only unique items from the collection.
      *
      * @param  string|null $key
+     * @param  bool $strict
      * @throws MappingException
      * @return self
      */
-    public function unique($key = null)
+    public function unique($key = null, $strict = false)
     {
         $dictionary = $this->getDictionary();
 

--- a/src/EntityMap.php
+++ b/src/EntityMap.php
@@ -654,7 +654,7 @@ class EntityMap
      */
     public function getInheritanceType()
     {
-        return $this->inheritanceType;
+        return property_exists($this, 'inheritanceType') ? $this->inheritanceType : null;
     }
 
     /**
@@ -665,7 +665,7 @@ class EntityMap
      */
     public function getDiscriminatorColumn()
     {
-        return $this->discriminatorColumn;
+        return property_exists($this, 'discriminatorColumn') ? $this->discriminatorColumn : null;
     }
 
     /**
@@ -675,7 +675,7 @@ class EntityMap
      */
     public function getDiscriminatorColumnMap()
     {
-        return $this->discriminatorColumnMap;
+        return property_exists($this, 'discriminatorColumnMap') ? $this->discriminatorColumnMap : null;
     }
 
     /**

--- a/src/EntityMap.php
+++ b/src/EntityMap.php
@@ -70,7 +70,7 @@ class EntityMap
      * @var array
      */
     protected $embeddables = [];
-        
+
     /**
      * Determine the relationships method used on the entity.
      * If not set, mapper will autodetect them
@@ -308,7 +308,7 @@ class EntityMap
     {
         $this->dateFormat = $format;
     }
-    
+
     /**
      * Get the date format to use with the current database connection
      *
@@ -369,7 +369,7 @@ class EntityMap
         if (!is_null($this->table)) {
             return $this->table;
         }
-        
+
         return str_replace('\\', '', snake_case(str_plural(class_basename($this->getClass()))));
     }
 
@@ -544,7 +544,7 @@ class EntityMap
     {
         return $this->primaryKey;
     }
-    
+
     /**
      * Set the primary key for the entity.
      *
@@ -555,7 +555,7 @@ class EntityMap
     {
         $this->primaryKey = $key;
     }
-    
+
     /**
      * Get the table qualified key name.
      *
@@ -648,6 +648,37 @@ class EntityMap
     }
 
     /**
+     * Return the inheritance type used by the entity.
+     *
+     * @return string|null
+     */
+    public function getInheritanceType()
+    {
+        return $this->inheritanceType;
+    }
+
+    /**
+     * Return the discriminator column name on the entity that's
+     * used for table inheritance.
+     *
+     * @return string
+     */
+    public function getDiscriminatorColumn()
+    {
+        return $this->discriminatorColumn;
+    }
+
+    /**
+     * Return the mapping of discriminator column values to
+     * entity class names that's used for table inheritance.
+     * @return string
+     */
+    public function getDiscriminatorColumnMap()
+    {
+        return $this->discriminatorColumnMap;
+    }
+
+    /**
      * Define a one-to-one relationship.
      *
      * @param         $entity
@@ -691,7 +722,7 @@ class EntityMap
         $relatedMapper = $this->manager->mapper($related);
 
         $table = $relatedMapper->getEntityMap()->getTable();
-        
+
         return new MorphOne($relatedMapper, $entity, $table . '.' . $type, $table . '.' . $id, $localKey);
     }
 
@@ -753,7 +784,7 @@ class EntityMap
         }
 
         list($type, $id) = $this->getMorphs($name, $type, $id);
-        
+
         $mapper = $this->manager->mapper(get_class($entity));
 
         // If the type value is null it is probably safe to assume we're eager loading
@@ -761,7 +792,7 @@ class EntityMap
         // there are multiple types in the morph and we can't use single queries.
         $factory = new Factory;
         $wrapper = $factory->make($entity);
-            
+
         if (is_null($class = $wrapper->getEntityAttribute($type))) {
             return new MorphTo(
                 $mapper, $entity, $id, null, $type, $name
@@ -776,7 +807,7 @@ class EntityMap
             $relatedMapper = $this->manager->mapper($class);
 
             $foreignKey = $relatedMapper->getEntityMap()->getKeyName();
-            
+
             return new MorphTo(
                 $relatedMapper, $entity, $id, $foreignKey, $type, $name
             );
@@ -856,7 +887,7 @@ class EntityMap
         $table = $relatedMapper->getEntityMap()->getTable();
 
         $localKey = $localKey ?: $this->getKeyName();
-        
+
         return new MorphMany($relatedMapper, $entity, $table . '.' . $type, $table . '.' . $id, $localKey);
     }
 
@@ -1027,7 +1058,7 @@ class EntityMap
         $morphClass = $this->manager->getMorphMap($this->getClass());
         return $this->morphClass ?: $morphClass;
     }
-    
+
     /**
      * Create a new Entity Collection instance.
      *
@@ -1082,7 +1113,7 @@ class EntityMap
         $mapMethods = get_class_methods($this);
 
         $parentsMethods = get_class_methods('Analogue\ORM\EntityMap');
-        
+
         return array_diff($mapMethods, $parentsMethods);
     }
 
@@ -1129,7 +1160,7 @@ class EntityMap
 
         // Instantiate a dummy entity which we will pass to relationship methods.
         $entity = unserialize(sprintf('O:%d:"%s":0:{}', strlen($entityClass), $entityClass));
-        
+
         foreach ($this->relationships as $relation) {
             $relationObject = $this->$relation($entity);
 

--- a/src/EntityMap.php
+++ b/src/EntityMap.php
@@ -670,12 +670,13 @@ class EntityMap
 
     /**
      * Return the mapping of discriminator column values to
-     * entity class names that's used for table inheritance.
-     * @return string
+     * entity class names that are used for table inheritance.
+     *
+     * @return array
      */
     public function getDiscriminatorColumnMap()
     {
-        return property_exists($this, 'discriminatorColumnMap') ? $this->discriminatorColumnMap : null;
+        return property_exists($this, 'discriminatorColumnMap') ? $this->discriminatorColumnMap : [];
     }
 
     /**

--- a/src/System/Query.php
+++ b/src/System/Query.php
@@ -753,8 +753,8 @@ class Query
         // Run the query
         $results = $this->query->get($columns)->toArray();
 
-        // $builder = new EntityBuilder($this->mapper, array_keys($this->getEagerLoads()));
-        $builder = new ResultBuilder($this->mapper, array_keys($this->getEagerLoads()));
+        // Create a result builder.
+        $builder = new ResultBuilder(Manager::getInstance(), $this->mapper, array_keys($this->getEagerLoads()));
 
         return $builder->build($results);
     }

--- a/src/System/Query.php
+++ b/src/System/Query.php
@@ -46,7 +46,7 @@ class Query
      * @var \Analogue\ORM\EntityMap
      */
     protected $entityMap;
-    
+
     /**
      * The relationships that should be eager loaded.
      *
@@ -255,7 +255,7 @@ class Query
             $results = $this->forPage($page, $count)->get();
         }
     }
-    
+
     /**
      * Get an array with the values of a given column.
      *
@@ -753,7 +753,8 @@ class Query
         // Run the query
         $results = $this->query->get($columns)->toArray();
 
-        $builder = new EntityBuilder($this->mapper, array_keys($this->getEagerLoads()));
+        // $builder = new EntityBuilder($this->mapper, array_keys($this->getEagerLoads()));
+        $builder = new ResultBuilder($this->mapper, array_keys($this->getEagerLoads()));
 
         return $builder->build($results);
     }
@@ -852,7 +853,7 @@ class Query
 
             return call_user_func_array($this->macros[$method], $parameters);
         }
-        
+
         if (in_array($method, $this->blacklist)) {
             throw new Exception("Method $method doesn't exist");
         }

--- a/src/System/ResultBuilder.php
+++ b/src/System/ResultBuilder.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Analogue\ORM\System;
+
+use Analogue\ORM\System\Mapper;
+
+class ResultBuilder
+{
+    /**
+     * An array of entity builder instances used to hydrate a result set.
+     *
+     * @var array
+     */
+    protected $entityBuilders = [];
+
+    /**
+     * The mapper for the entity to build
+     * @var \Analogue\ORM\System\Mapper
+     */
+    protected $mapper;
+
+    /**
+     * The Entity Map for the entity to build.
+     *
+     * @var \Analogue\ORM\EntityMap
+     */
+    protected $entityMap;
+
+    /**
+     * Relations that will be eager loaded on this query
+     *
+     * @var array
+     */
+    protected $eagerLoads;
+
+    /**
+     * An array of builders used by this class to build necessary
+     * entities for each result type.
+     *
+     * @var array
+     */
+    protected $builders = [];
+
+    /**
+     * @param Mapper $mapper
+     * @param array  $eagerLoads
+     */
+    public function __construct(Mapper $mapper, array $eagerLoads)
+    {
+        $this->mapper = $mapper;
+
+        $this->eagerLoads = $eagerLoads;
+
+        $this->entityMap = $mapper->getEntityMap();
+    }
+
+    /**
+     * Convert a result set into an array of entities
+     *
+     * @param  array $results
+     * @return \Illuminate\Support\Collection
+     */
+    public function build($results)
+    {
+        switch ($this->entityMap->getInheritanceType()) {
+            case 'single_table':
+                return $this->buildUsingSingleTableInheritance($results);
+                break;
+
+            default:
+                return $this->buildWithDefaultMapper($results);
+                break;
+        }
+    }
+
+    /**
+     * Build an entity from results, using the default mapper on this builder.
+     * This is the default build plan when no table inheritance is being used.
+     *
+     * @param  array $results
+     * @return Collection
+     */
+    protected function buildWithDefaultMapper($results)
+    {
+        $builder = new EntityBuilder($this->mapper, array_keys($this->eagerLoads));
+
+        return collect($results)->map(function($item, $key) use ($builder) {
+            return $builder->build((array) $item);
+        })->all();
+    }
+
+    /**
+     * Build an entity from results, using single table inheritance.
+     *
+     * @param  array $results
+     * @return Collection
+     */
+    protected function buildUsingSingleTableInheritance($results)
+    {
+        return collect($results)->map(function($item, $key) {
+            $builder = $this->builderForResult((array) $item);
+
+            return $builder->build((array) $item);
+        })->all();
+    }
+
+    /**
+     * Given a result array, return the entity builder needed to correctly
+     * build the result into an entity.
+     *
+     * @param  array  $result
+     * @return EntityBuilder
+     */
+    protected function builderForResult(array $result) : EntityBuilder
+    {
+        $type = $result[$this->entityMap->getDiscriminatorColumn()];
+        $class = $this->entityMap->getDiscriminatorColumnMap()[$type];
+
+        if (!isset($this->builders[$type])) {
+            $manager = app('analogue');
+            $this->builders[$type] = new EntityBuilder($manager->mapper($class), array_keys($this->eagerLoads));
+        }
+
+        return $this->builders[$type];
+    }
+}

--- a/src/System/ResultBuilder.php
+++ b/src/System/ResultBuilder.php
@@ -108,7 +108,10 @@ class ResultBuilder
 
     /**
      * Given a result array, return the entity builder needed to correctly
-     * build the result into an entity.
+     * build the result into an entity. If no getDiscriminatorColumnMap property
+     * has been defined on the EntityMap, we'll assume that the value stored in
+     * the $type column is the fully qualified class name of the entity and
+     * we'll use it instead.
      *
      * @param  array  $result
      * @return EntityBuilder
@@ -116,7 +119,10 @@ class ResultBuilder
     protected function builderForResult(array $result) : EntityBuilder
     {
         $type = $result[$this->entityMap->getDiscriminatorColumn()];
-        $class = $this->entityMap->getDiscriminatorColumnMap()[$type];
+
+        $columnMap = $this->entityMap->getDiscriminatorColumnMap();
+
+        $class = isset($columnMap[$type]) ? $columnMap[$type]: $type;
 
         if (!isset($this->builders[$type])) {
             $this->builders[$type] = new EntityBuilder($this->manager->mapper($class), array_keys($this->eagerLoads));

--- a/src/System/ResultBuilder.php
+++ b/src/System/ResultBuilder.php
@@ -84,7 +84,7 @@ class ResultBuilder
      */
     protected function buildWithDefaultMapper($results)
     {
-        $builder = new EntityBuilder($this->defaulMapper, array_keys($this->eagerLoads));
+        $builder = new EntityBuilder($this->defaultMapper, array_keys($this->eagerLoads));
 
         return collect($results)->map(function($item, $key) use ($builder) {
             return $builder->build((array) $item);


### PR DESCRIPTION
I've taken a stab at implementing #101. This is probably going to need some cleanup, but I've tried to following the concepts that you laid out (namely, using higher level ResultBuilder that builds out an array of entities by calling each the appropriate ResultBuilder for each record). 
To implement table inheritance, all you have to do is define some meta values on the base mapper class. As example, we could define the following configuration on a base Vehicle mapper:
```php
/**
     * @var string
     */
    protected $inheritanceType = "single_table";

    /**
     * @var string
     */
    protected $discriminatorColumn = "type";

    /**
     * @var array
     */
    protected $discriminatorColumnMap = [
        "vehicle" => "App\Entities\Vehicle",
        "car"     => "App\Entities\Car",
        "truck"   => "App\Entities\Truck"
    ];
```

This follows the same inheritance mapping configuration as used by [Doctrine](http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/inheritance-mapping.html). I did this for the following reasons:

1. People that have used Doctrine before and are familiar with this configuration will be able to get up and running quicker.
2. This opens the door for us to implement class table inheritance later on (which would be very nice to have but is beyond the scope of this PR).

The only major issue I have with this is that I wasn't able to figure out how to get an instance of the `Manager` class without using Laravel's IOC container (which might not be the most ideal way to do that and feels a bit weird to be doing). Please let me know what you think.