### PR TITLE
Fix relationship loading bug when using STI.

### DIFF
--- a/src/EntityMap.php
+++ b/src/EntityMap.php
@@ -1141,7 +1141,7 @@ class EntityMap
             if ($method->getNumberOfParameters() > 0) {
                 $params = $method->getParameters();
 
-                if ($params[0]->getClass() && $params[0]->getClass()->name == $entityClass) {
+                if ($params[0]->getClass() && ($params[0]->getClass()->name == $entityClass || is_subclass_of($entityClass, $params[0]->getClass()->name))) {
                     $relationships[] = $methodName;
                 }
             }


### PR DESCRIPTION
Remi this is a bug I found a couple of days ago with the STI implementation that we did last month but it never made it into the original PR that you just merged (I'm sorry).

When using STI, the entity map would previously fail to detect a relationship
definition because it was only checking that the name of the first param (in the definition)
was of the exact same class as the entity for the map. However, when using STI this won't always be
the case and so we need to also allow for the entity to be a subclass of the param.