### PR TITLE
Allow mappers to save subclass entities.

### DIFF
--- a/src/System/Mapper.php
+++ b/src/System/Mapper.php
@@ -96,7 +96,7 @@ class Mapper
 
     /**
      * Map results to a Collection
-     * 
+     *
      * @param  [type] $results [description]
      * @return [type]          [description]
      */
@@ -107,7 +107,7 @@ class Mapper
 
     /**
      * Return all records for a mapped object
-     * 
+     *
      * @return EntityCollection
      */
     public function all()
@@ -179,7 +179,7 @@ class Mapper
      */
     protected function checkEntityType($entity)
     {
-        if (get_class($entity) != $this->entityMap->getClass()) {
+        if (get_class($entity) != $this->entityMap->getClass() && !is_subclass_of($entity, $this->entityMap->getClass())) {
             $expected = $this->entityMap->getClass();
             $actual = get_class($entity);
             throw new InvalidArgumentException("Expected : $expected, got $actual.");
@@ -427,8 +427,8 @@ class Mapper
 
         if($this->entityMap->useDependencyInjection()) {
             return $this->newInstanceUsingDependencyInjection($class);
-        } 
-        
+        }
+
         return $this->newInstanceUsingInstantiator($class);
     }
 


### PR DESCRIPTION
The STI implementation that we worked on a couple of months ago is still unusable for me without this PR; I have it implemented on the 5.1.* branch of my fork (I use it for an app I've been building at work and this solution works nicely), but we're upgrading the app to Laravel 5.3 and I need to  use the 5.3-dev branch branch and this never got merged into the original PR. We talked about this in the conversation for the previous PR: https://github.com/analogueorm/analogue/pull/131#issuecomment-245150719. Please consider merging this in, for the reason discussed in that comment thread. Also, if you want help writing tests for this feature (or anything else that I can help with) just let me know. I'm in Laravel slack as *tabennett*. Thank you for your time and work you put into this project.