### PR TITLE
fixed issue with global event handlers in Plugins

### DIFF
--- a/src/Plugins/SoftDeletes/SoftDeletesPlugin.php
+++ b/src/Plugins/SoftDeletes/SoftDeletesPlugin.php
@@ -24,7 +24,8 @@ class SoftDeletesPlugin extends AnaloguePlugin
         $host = $this;
 
         // Hook any mapper init and check the mapping include soft deletes.
-        $this->manager->registerGlobalEvent('initialized', function (Mapper $mapper) use ($host) {
+        $this->manager->registerGlobalEvent('initialized', function ($name, array $data) use ($host) {
+            $mapper = $data[0];
             $entityMap = $mapper->getEntityMap();
 
             if ($entityMap->usesSoftDeletes()) {

--- a/src/Plugins/Timestamps/TimestampsPlugin.php
+++ b/src/Plugins/Timestamps/TimestampsPlugin.php
@@ -20,7 +20,8 @@ class TimestampsPlugin extends AnaloguePlugin
      */
     public function register()
     {
-        $this->manager->registerGlobalEvent('initialized', function (Mapper $mapper) {
+        $this->manager->registerGlobalEvent('initialized', function ($name, array $data) {
+            $mapper = $data[0];
             $entityMap = $mapper->getEntityMap();
 
             if ($entityMap->usesTimestamps()) {


### PR DESCRIPTION
The global event handlers were being passed the event name and an array of data, rather than just the `Mapper` object.