### PR TITLE
Fix call to dynamic relationship in EntityMap magic __call() method

### DIFF
--- a/src/EntityMap.php
+++ b/src/EntityMap.php
@@ -1287,7 +1287,7 @@ class EntityMap
         // Add $this to parameters so the closure can call relationship method on the map.
         $parameters[] = $this;
 
-        return  call_user_func_array([$this->dynamicRelationships[$method], $parameters]);
+        return  call_user_func_array($this->dynamicRelationships[$method], $parameters);
     }
 
     /**


### PR DESCRIPTION
When trying to add a dynamic relationship I received an error 

> call_user_func_array() expects exactly 2 parameters

magic `__call()` in EntityMap was trying to pass one single array to `call_user_func_array()`, I removed the array brackets to fix this.