### PR TITLE
Fix for missing hydration handling of popo with custom attributes

### DIFF
--- a/src/System/Wrappers/PlainObjectWrapper.php
+++ b/src/System/Wrappers/PlainObjectWrapper.php
@@ -124,13 +124,14 @@ class PlainObjectWrapper extends Wrapper
 
         foreach ($properties as $property) {
             $name = $property->getName();
+            $column = $this->getMap()->getColumnNameForAttribute($name);
 
             if ($property->isPublic()) {
-                $this->entity->$name = $attributes[$name];
+                $this->entity->$name = $attributes[$column];
             } else {
                 $property->setAccessible(true);
-                if (isset($attributes[$name])) {
-                    $property->setValue($this->entity, $attributes[$name]);
+                if (isset($attributes[$column])) {
+                    $property->setValue($this->entity, $attributes[$column]);
                 }
             }
         }

--- a/tests/cases/ReflectionMappingTest.php
+++ b/tests/cases/ReflectionMappingTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use TestApp\CustomAttributeRealisator;
 use TestApp\Movie;
 use TestApp\Realisator;
 
@@ -59,5 +60,18 @@ class ReflectionMappingTest extends DomainTestCase
             'title'         => 'A clockwork orange',
             'realisator_id' => $realisator->id,
         ]);
+    }
+
+    /** @test */
+    public function we_can_store_and_retrieve_a_plain_php_object_with_a_custom_attribute_mapping()
+    {
+        $realisator = new CustomAttributeRealisator('Stanley Kubrick');
+        $mapper = $this->mapper(CustomAttributeRealisator::class);
+        $mapper->store($realisator);
+        $this->seeInDatabase('realisators', [
+            'name' => 'Stanley Kubrick',
+        ]);
+        $foundRealisator = $mapper->find($realisator->id);
+        $this->matches('Stanley Kubrick')->evaluate($foundRealisator->getName());
     }
 }

--- a/tests/src/CustomAttributeRealisator.php
+++ b/tests/src/CustomAttributeRealisator.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace TestApp;
+
+class CustomAttributeRealisator
+{
+    /**
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @var string
+     */
+    protected $realisatorName;
+
+    public function __construct($name)
+    {
+        $this->realisatorName = $name;
+    }
+
+    public function getName()
+    {
+        return $this->realisatorName;
+    }
+}

--- a/tests/src/Maps/CustomAttributeRealisatorMap.php
+++ b/tests/src/Maps/CustomAttributeRealisatorMap.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace TestApp\Maps;
+
+use Analogue\ORM\EntityMap;
+
+class CustomAttributeRealisatorMap extends EntityMap
+{
+    protected $table = 'realisators';
+
+    protected $attributes = [
+        'name' => 'realisatorName',
+    ];
+}


### PR DESCRIPTION
I found that the mapping of custom attributes would fail on hydration using the `PlainObjectWrapper`. This adds a fix and updates the tests to include checks for the case.