### PR TITLE
Added value() to Query pass through methods

### DIFF
--- a/src/System/Query.php
+++ b/src/System/Query.php
@@ -70,6 +70,7 @@ class Query
         'toSql',
         'lists',
         'pluck',
+        'value',
         'count',
         'min',
         'max',


### PR DESCRIPTION
This allows using `->value()` on query builders to retrieve a single column value from the first result of a query.

https://laravel.com/docs/5.4/queries#retrieving-results