### PR TITLE
Removed Mapper mixin annotation from the Repository class

### DIFF
--- a/src/Repository.php
+++ b/src/Repository.php
@@ -10,8 +10,6 @@ use InvalidArgumentException;
 
 /**
  * Class Repository.
- *
- * @mixin Mapper
  */
 class Repository
 {


### PR DESCRIPTION
This annotation causes conflicts in PhpStorm when I try to write methods on repository extensions with the same name as mapper methods. It also means that repositories auto-complete for methods that aren't actually available.

Because the magic `Repository::__call` method only forwards calls to custom commands registered with the mapper, I felt it would be appropriate to remove this annotation.

The `Repository::__call` method in 5.4:

```php
/**
 * Make custom mapper custom commands available in repository.
 *
 * @param string $method
 * @param array  $parameters
 *
 * @throws Exception
 *
 * @return mixed
 */
public function __call($method, $parameters)
{
	if ($this->mapper->hasCustomCommand($method)) {
		call_user_func_array([$this->mapper, $method], $parameters);
	} else {
		throw new Exception("No method $method on ".get_class($this));
	}
}
```