### PR TITLE
Fixed docblock references to undefined QueryAdapter classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.phar
 composer.lock
 .DS_Store
 psr2
+.idea

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -24,8 +24,8 @@ abstract class Command
     /**
      * Command constructor.
      *
-     * @param Aggregate                                                 $aggregate
-     * @param QueryAdapter|\Analogue\ORM\Drivers\IlluminateQueryAdapter $query
+     * @param Aggregate $aggregate
+     * @param Builder   $query
      */
     public function __construct(Aggregate $aggregate, Builder $query)
     {

--- a/src/Drivers/DBAdapter.php
+++ b/src/Drivers/DBAdapter.php
@@ -7,7 +7,7 @@ interface DBAdapter
     /**
      * Return's Driver specific Query Implementation.
      *
-     * @return \Analogue\ORM\Drivers\QueryAdapter|\Analogue\ORM\Drivers\IlluminateQueryAdapter
+     * @return IlluminateQueryBuilder
      */
     public function getQuery();
 

--- a/src/Drivers/IlluminateQueryBuilder.php
+++ b/src/Drivers/IlluminateQueryBuilder.php
@@ -5,7 +5,7 @@ namespace Analogue\ORM\Drivers;
 use Illuminate\Database\Query\Builder;
 
 /**
- * Class IlluminateQueryAdapter.
+ * Class IlluminateQueryBuilder.
  *
  * @mixin Builder
  */

--- a/src/System/Query.php
+++ b/src/System/Query.php
@@ -3,6 +3,7 @@
 namespace Analogue\ORM\System;
 
 use Analogue\ORM\Drivers\DBAdapter;
+use Analogue\ORM\Drivers\IlluminateQueryBuilder;
 use Analogue\ORM\EntityCollection;
 use Analogue\ORM\Exceptions\EntityNotFoundException;
 use Analogue\ORM\Relationships\Relationship;
@@ -15,7 +16,7 @@ use Illuminate\Pagination\Paginator;
 /**
  * Analogue Query builder.
  *
- * @mixin QueryAdapter|\Analogue\ORM\Drivers\IlluminateQueryAdapter
+ * @mixin IlluminateQueryBuilder
  */
 class Query
 {
@@ -36,7 +37,7 @@ class Query
     /**
      * Query Builder Instance.
      *
-     * @var \Analogue\ORM\Drivers\QueryAdapter|\Analogue\ORM\Drivers\IlluminateQueryAdapter
+     * @var IlluminateQueryBuilder
      */
     protected $query;
 
@@ -868,7 +869,7 @@ class Query
      * (REFACTOR: this method should move out, we need to provide the client classes
      * with the adapter instead.)
      *
-     * @return \Analogue\ORM\Drivers\QueryAdapter|\Analogue\ORM\Drivers\IlluminateQueryAdapter
+     * @return IlluminateQueryBuilder
      */
     public function getQuery()
     {


### PR DESCRIPTION
This fixes IDE auto-completion for Query Builders in a few places.