### PR TITLE
[FIX] Typos, imports and other stuff

### DIFF
--- a/src/Drivers/DBAdapter.php
+++ b/src/Drivers/DBAdapter.php
@@ -7,7 +7,7 @@ interface DBAdapter
     /**
      * Return's Driver specific Query Implementation.
      *
-     * @return \Analogue\ORM\Drivers\QueryAdapter|\Analogue\ORM\Drivers\IlluminateQueryAdapter
+     * @return \Analogue\ORM\Drivers\QueryAdapter|\Analogue\ORM\Drivers\IlluminateQueryBuilder
      */
     public function getQuery();
 

--- a/src/Drivers/IlluminateDBAdapter.php
+++ b/src/Drivers/IlluminateDBAdapter.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Connection;
 
 /**
  * Illuminate Driver for Analogue ORM. If multiple DB connections are
- * involved, we'll treat each underlyin driver as a separate instance.
+ * involved, we'll treat each underlying driver as a separate instance.
  */
 class IlluminateDBAdapter implements DBAdapter
 {

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -73,7 +73,7 @@ class Entity extends ValueObject
      */
     protected function hasGetMutator($key)
     {
-        return method_exists($this, 'get'.$this->getMutatorMethod($key)) ? true : false;
+        return method_exists($this, 'get'.$this->getMutatorMethod($key));
     }
 
     /**
@@ -85,7 +85,7 @@ class Entity extends ValueObject
      */
     protected function hasSetMutator($key)
     {
-        return method_exists($this, 'set'.$this->getMutatorMethod($key)) ? true : false;
+        return method_exists($this, 'set'.$this->getMutatorMethod($key));
     }
 
     /**

--- a/src/EntityCollection.php
+++ b/src/EntityCollection.php
@@ -407,7 +407,7 @@ class EntityCollection extends Collection
      * @param string      $value
      * @param string|null $key
      *
-     * @return self
+     * @return \Illuminate\Support\Collection
      */
     public function pluck($value, $key = null)
     {
@@ -420,7 +420,7 @@ class EntityCollection extends Collection
      * @param string      $value
      * @param string|null $key
      *
-     * @return self
+     * @return \Illuminate\Support\Collection
      */
     public function lists($value, $key = null)
     {

--- a/src/EntityMap.php
+++ b/src/EntityMap.php
@@ -51,7 +51,7 @@ class EntityMap
      * The primary key for the model. If the model is an Embedded Value object
      * primary key is set to null.
      *
-     * @var string | null
+     * @var string|null
      */
     protected $primaryKey = 'id';
 
@@ -287,7 +287,7 @@ class EntityMap
 
     /**
      * Allow using a string to define which entity type should be instantiated.
-     * If not set, analogue will uses entity's FQDN.
+     * If not set, analogue will uses entity's FQCN.
      *
      * @var array
      */
@@ -614,6 +614,8 @@ class EntityMap
      *
      * @param string $relation
      *
+     * @throws MappingException
+     *
      * @return mixed
      */
     public function getEmptyValueForRelationship(string $relation)
@@ -626,7 +628,7 @@ class EntityMap
             return new Collection();
         }
 
-        throw new MappingException("Cannot determine defaut value of $relation");
+        throw new MappingException("Cannot determine default value of $relation");
     }
 
     /**
@@ -667,7 +669,7 @@ class EntityMap
      *
      * @param string $relation
      *
-     * @return string | array | null
+     * @return string|array|null
      */
     public function getLocalKeys($relation)
     {
@@ -717,11 +719,11 @@ class EntityMap
     }
 
     /**
-     * Get the targetted type for a relationship. Return null if polymorphic.
+     * Get the targeted type for a relationship. Return null if polymorphic.
      *
      * @param string $relation
      *
-     * @return string | null
+     * @return string|null
      */
     public function getTargettedClass($relation)
     {
@@ -770,7 +772,7 @@ class EntityMap
     /**
      * Get the primary key attribute for the entity.
      *
-     * @return string | null
+     * @return string|null
      */
     public function getKeyName()
     {
@@ -1023,8 +1025,9 @@ class EntityMap
     /**
      * Define an Embedded Object.
      *
-     * @param mixed  $entity
-     * @param string $related
+     * @param mixed  $parent
+     * @param string $relatedClass
+     * @param string $relation
      *
      * @return EmbedsOne
      */
@@ -1044,10 +1047,11 @@ class EntityMap
     /**
      * Define an Embedded Collection.
      *
-     * @param mixed  $entity
-     * @param string $related
+     * @param mixed  $parent
+     * @param string $relatedClass
+     * @param string $relation
      *
-     * @return EmbedsOne
+     * @return EmbedsMany
      */
     public function embedsMany($parent, string $relatedClass, $relation = null) : EmbedsMany
     {
@@ -1151,7 +1155,6 @@ class EntityMap
      * @param string      $related
      * @param string|null $foreignKey
      * @param string|null $otherKey
-     * @param string|null $relation
      *
      * @throws MappingException
      *
@@ -1356,11 +1359,10 @@ class EntityMap
      * Define a many-to-many relationship.
      *
      * @param mixed       $entity
-     * @param string      $relatedClass
+     * @param string      $related
      * @param string|null $table
      * @param string|null $foreignKey
      * @param string|null $otherKey
-     * @param string|null $relation
      *
      * @throws MappingException
      *
@@ -1537,7 +1539,7 @@ class EntityMap
      */
     public function newCollection(array $entities = [])
     {
-        return new EntityCollection($entities, $this);
+        return new EntityCollection($entities);
     }
 
     /**
@@ -1568,7 +1570,7 @@ class EntityMap
      */
     public function boot()
     {
-        if (count($this->relationships > 0)) {
+        if (count($this->relationships) > 0) {
             $this->sortRelationshipsByType();
         }
 
@@ -1635,9 +1637,9 @@ class EntityMap
     /**
      * Sort Relationships methods by type.
      *
-     * TODO : replace this by direclty setting these value
+     * TODO : replace this by directly setting these value
      * in the corresponding methods, so we won't need
-     * the correpondancy tabble
+     * the correspondency table
      *
      * @return void
      */

--- a/src/Relationships/BelongsTo.php
+++ b/src/Relationships/BelongsTo.php
@@ -2,7 +2,7 @@
 
 namespace Analogue\ORM\Relationships;
 
-use Analogue\ORM\EntityCollection;
+use Analogue\ORM\Exceptions\MappingException;
 use Analogue\ORM\Mappable;
 use Analogue\ORM\System\Mapper;
 use Analogue\ORM\System\Query;

--- a/src/Relationships/BelongsToMany.php
+++ b/src/Relationships/BelongsToMany.php
@@ -9,6 +9,7 @@ use Analogue\ORM\System\InternallyMappable;
 use Analogue\ORM\System\Mapper;
 use Analogue\ORM\System\Query;
 use Illuminate\Database\Query\Expression;
+use Illuminate\Support\Collection;
 
 class BelongsToMany extends Relationship
 {
@@ -193,9 +194,9 @@ class BelongsToMany extends Relationship
      *
      * @param array $columns
      *
-     * @return \Analogue\ORM\EntityCollection
+     * @return \Illuminate\Support\Collection
      */
-    public function get($columns = ['*'])
+    public function get($columns = ['*']) : Collection
     {
         // First we'll add the proper select columns onto the query so it is run with
         // the proper columns. Then, we will get the results and hydrate out pivot

--- a/src/Relationships/EmbeddedRelationship.php
+++ b/src/Relationships/EmbeddedRelationship.php
@@ -5,7 +5,6 @@ namespace Analogue\ORM\Relationships;
 use Analogue\ORM\System\Manager;
 use Analogue\ORM\System\ResultBuilder;
 use Analogue\ORM\System\Wrappers\Factory;
-use Analogue\ORM\System\Wrappers\Wrapper;
 
 abstract class EmbeddedRelationship
 {
@@ -154,7 +153,7 @@ abstract class EmbeddedRelationship
      * Get attribute name from the parent, if a map has been
      * defined.
      *
-     * @param srring $attributeKey
+     * @param string $key
      *
      * @return string
      */
@@ -217,7 +216,7 @@ abstract class EmbeddedRelationship
     /**
      * Return parent mapper.
      *
-     * @return Analogue\ORM\System\Mapper
+     * @return \Analogue\ORM\System\Mapper
      */
     protected function getParentMapper()
     {
@@ -227,7 +226,7 @@ abstract class EmbeddedRelationship
     /**
      * Return embedded relationship mapper.
      *
-     * @return Analogue\ORM\System\Mapper
+     * @return \Analogue\ORM\System\Mapper
      */
     protected function getRelatedMapper()
     {

--- a/src/Relationships/EmbedsMany.php
+++ b/src/Relationships/EmbedsMany.php
@@ -34,6 +34,7 @@ class EmbedsMany extends EmbedsOne
      * @param array $attributes
      *
      * @throws MappingException
+     *
      * @return array
      */
     protected function matchAsArray(array $attributes) : array
@@ -79,6 +80,7 @@ class EmbedsMany extends EmbedsOne
      * @param mixed $objects
      *
      * @throws MappingException
+     *
      * @return array $columns
      */
     public function normalize($objects) : array
@@ -96,6 +98,7 @@ class EmbedsMany extends EmbedsOne
      * @param mixed $objects
      *
      * @throws MappingException
+     *
      * @return array
      */
     protected function normalizeAsArray($objects) : array

--- a/src/Relationships/EmbedsMany.php
+++ b/src/Relationships/EmbedsMany.php
@@ -13,6 +13,7 @@ class EmbedsMany extends EmbedsOne
      *
      * @param array $attributes
      *
+     * @throws MappingException
      * @return array
      */
     public function matchSingleResult(array $attributes) : array
@@ -32,6 +33,7 @@ class EmbedsMany extends EmbedsOne
      *
      * @param array $attributes
      *
+     * @throws MappingException
      * @return array
      */
     protected function matchAsArray(array $attributes) : array
@@ -74,8 +76,9 @@ class EmbedsMany extends EmbedsOne
     /**
      * Transform embedded object into db column(s).
      *
-     * @param mixed $object
+     * @param mixed $objects
      *
+     * @throws MappingException
      * @return array $columns
      */
     public function normalize($objects) : array
@@ -90,8 +93,9 @@ class EmbedsMany extends EmbedsOne
     /**
      * Normalize object an array containing raw attributes.
      *
-     * @param mixed $object
+     * @param mixed $objects
      *
+     * @throws MappingException
      * @return array
      */
     protected function normalizeAsArray($objects) : array

--- a/src/Relationships/EmbedsMany.php
+++ b/src/Relationships/EmbedsMany.php
@@ -14,6 +14,7 @@ class EmbedsMany extends EmbedsOne
      * @param array $attributes
      *
      * @throws MappingException
+     *
      * @return array
      */
     public function matchSingleResult(array $attributes) : array

--- a/src/Relationships/EmbedsOne.php
+++ b/src/Relationships/EmbedsOne.php
@@ -46,6 +46,7 @@ class EmbedsOne extends EmbeddedRelationship
      * @param array $attributes
      *
      * @throws MappingException
+     *
      * @return array
      */
     protected function matchAsArray(array $attributes) : array

--- a/src/Relationships/EmbedsOne.php
+++ b/src/Relationships/EmbedsOne.php
@@ -2,6 +2,8 @@
 
 namespace Analogue\ORM\Relationships;
 
+use Analogue\ORM\Exceptions\MappingException;
+
 class EmbedsOne extends EmbeddedRelationship
 {
     /**
@@ -13,7 +15,7 @@ class EmbedsOne extends EmbeddedRelationship
 
     /**
      * Transform attributes into embedded object(s), and
-     * match it into the given resultset.
+     * match it into the given result set.
      *
      * @param array $results
      *
@@ -43,6 +45,7 @@ class EmbedsOne extends EmbeddedRelationship
      *
      * @param array $attributes
      *
+     * @throws MappingException
      * @return array
      */
     protected function matchAsArray(array $attributes) : array
@@ -96,7 +99,7 @@ class EmbedsOne extends EmbeddedRelationship
     }
 
     /**
-     * Return a dictionnary of attributes key on parent Entity.
+     * Return a dictionary of attributes key on parent Entity.
      *
      * @return array
      */
@@ -107,7 +110,7 @@ class EmbedsOne extends EmbeddedRelationship
 
         $attributesMap = [];
 
-        // Build a dictionnary for corresponding object attributes => parent attributes
+        // Build a dictionary for corresponding object attributes => parent attributes
         foreach ($embeddedAttributeKeys as $key) {
             $attributesMap[$key] = $this->getParentAttributeKey($key);
         }

--- a/src/Relationships/HasMany.php
+++ b/src/Relationships/HasMany.php
@@ -23,7 +23,7 @@ class HasMany extends HasOneOrMany
     /**
      * Match the eagerly loaded results to their parents.
      *
-     * @param array  $$results
+     * @param array  $results
      * @param string $relation
      *
      * @return array

--- a/src/Relationships/HasManyThrough.php
+++ b/src/Relationships/HasManyThrough.php
@@ -291,7 +291,7 @@ class HasManyThrough extends Relationship
      * Run synchronization content if needed by the
      * relation type.
      *
-     * @param array $actualContent
+     * @param array $entities
      *
      * @return void
      */

--- a/src/Relationships/MorphTo.php
+++ b/src/Relationships/MorphTo.php
@@ -141,7 +141,7 @@ class MorphTo extends BelongsTo
      *
      * @throws \Analogue\ORM\Exceptions\MappingException
      *
-     * @return EntityCollection
+     * @return \Illuminate\Support\Collection
      */
     protected function getResultsByType($type)
     {
@@ -192,7 +192,7 @@ class MorphTo extends BelongsTo
     /**
      * Get the foreign key value pair for a related object.
      *
-     * @var mixed
+     * @param mixed $related
      *
      * @return array
      */

--- a/src/Relationships/Pivot.php
+++ b/src/Relationships/Pivot.php
@@ -82,7 +82,7 @@ class Pivot extends Entity
         // The pivot model is a "dynamic" model since we will set the tables dynamically
         // for the instance. This allows it work for any intermediate tables for the
         // many to many relationship that are defined by this developer's classes.
-        $this->setEntityAttributes($attributes, true);
+        $this->setEntityAttributes($attributes);
 
         $this->table = $table;
 

--- a/src/Relationships/Relationship.php
+++ b/src/Relationships/Relationship.php
@@ -167,7 +167,7 @@ abstract class Relationship
     /**
      * Get the relationship for eager loading.
      *
-     * @return EntityCollection
+     * @return \Illuminate\Support\Collection
      */
     public function getEager()
     {

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -51,7 +51,7 @@ class Repository
     /**
      * Return all Entities from database.
      *
-     * @return \Analogue\ORM\EntityCollection
+     * @return \Illuminate\Support\Collection
      */
     public function all()
     {

--- a/src/System/Aggregate.php
+++ b/src/System/Aggregate.php
@@ -399,7 +399,7 @@ class Aggregate implements InternallyMappable
     /**
      * Return the Mapper's entity cache.
      *
-     * @return \Analogue\ORM\System\EntityCache
+     * @return \Analogue\ORM\System\Cache\AttributeCache
      */
     protected function getEntityCache()
     {
@@ -661,7 +661,7 @@ class Aggregate implements InternallyMappable
             $type = array_search($entityClass, $map);
 
             if ($type === false) {
-                // Use entity FQDN if no corresponding key is set
+                // Use entity FQCN if no corresponding key is set
                 $attributes[$discriminatorColumn] = $entityClass;
             } else {
                 $attributes[$discriminatorColumn] = $type;
@@ -805,6 +805,8 @@ class Aggregate implements InternallyMappable
      * Get a null foreign key value pair for an empty relationship.
      *
      * @param string $relation
+     *
+     * @throws MappingException
      *
      * @return array
      */
@@ -1092,7 +1094,7 @@ class Aggregate implements InternallyMappable
     /**
      * Return cache instance for the current entity type.
      *
-     * @return \Analogue\ORM\System\EntityCache
+     * @return \Analogue\ORM\System\Cache\AttributeCache
      */
     protected function getCache()
     {
@@ -1100,7 +1102,7 @@ class Aggregate implements InternallyMappable
     }
 
     /**
-     * Get Only Raw Entiy's attributes which have been modified
+     * Get Only Raw Entity attributes which have been modified
      * since last query.
      *
      * @return array
@@ -1263,7 +1265,7 @@ class Aggregate implements InternallyMappable
     }
 
     /**
-     * Set the lazyloading proxies on the wrapped entity.
+     * Set the lazy loading proxies on the wrapped entity.
      *
      * @return void
      */

--- a/src/System/Cache/AttributeCache.php
+++ b/src/System/Cache/AttributeCache.php
@@ -98,7 +98,7 @@ class AttributeCache
      *
      * @param array $result
      *
-     * @return
+     * @return array
      */
     protected function rawResult(array $result) : array
     {
@@ -139,7 +139,7 @@ class AttributeCache
      * Combine new result set with existing attributes in
      * cache.
      *
-     * @param array $entities
+     * @param array $results
      *
      * @return void
      */
@@ -365,7 +365,7 @@ class AttributeCache
 
     /**
      * Clear the entity Cache. Use with caution as it could result
-     * in impredictable behaviour if the cached entities are stored
+     * in unpredictable behaviour if the cached entities are stored
      * after the cache clear operation.
      *
      * @return void

--- a/src/System/Cache/InstanceCache.php
+++ b/src/System/Cache/InstanceCache.php
@@ -31,6 +31,8 @@ class InstanceCache
      * @param mixed  $entity
      * @param string $id
      *
+     * @throws CacheException
+     *
      * @return void
      */
     public function add($entity, $id)
@@ -65,12 +67,14 @@ class InstanceCache
      *
      * @param string $id
      *
+     * @throws CacheException
+     *
      * @return mixed|null
      */
     public function get($id)
     {
         if ($id === null) {
-            throw new CacheException('Cached isntance id cannot be null');
+            throw new CacheException('Cached instance id cannot be null');
         }
 
         if (!$this->has($id)) {

--- a/src/System/Manager.php
+++ b/src/System/Manager.php
@@ -11,14 +11,12 @@ use Analogue\ORM\Plugins\AnaloguePluginInterface;
 use Analogue\ORM\Repository;
 use Analogue\ORM\System\Wrappers\Wrapper;
 use Analogue\ORM\ValueMap;
-use Exception;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Support\Collection;
 use Psr\SimpleCache\CacheInterface;
 
 /**
  * This class is the entry point for registering Entities and
- * instansiating Mappers.
+ * instantiating Mappers.
  */
 class Manager
 {
@@ -299,7 +297,7 @@ class Manager
     /**
      * Check if a value class is already registered.
      *
-     * @param string|sdtClass $object
+     * @param string|\stdClass $object
      *
      * @return bool
      */
@@ -347,7 +345,7 @@ class Manager
     /**
      * Return proxy path if defined.
      *
-     * @return string | null
+     * @return string|null
      */
     public function getProxyPath()
     {
@@ -454,9 +452,9 @@ class Manager
     /**
      * Get Entity Map instance from cache.
      *
-     * @param string $entity
+     * @param string $entityClass
      *
-     * @return EntityMap | null
+     * @return EntityMap|null
      */
     protected function getEntityMapInstanceFromCache(string $entityClass)
     {
@@ -661,7 +659,7 @@ class Manager
     /**
      * Set an application cache.
      *
-     * @param Psr\SimpleCache\CacheInterface $cache
+     * @param \Psr\SimpleCache\CacheInterface $cache
      */
     public function setCache(CacheInterface $cache)
     {
@@ -729,7 +727,7 @@ class Manager
      * @throws MappingException
      * @throws \InvalidArgumentException
      *
-     * @return \Illuminate\Support\Collection|null
+     * @return \Traversable|array
      */
     public function delete($entity)
     {

--- a/src/System/Mapper.php
+++ b/src/System/Mapper.php
@@ -10,8 +10,6 @@ use Analogue\ORM\Exceptions\MappingException;
 use Analogue\ORM\Mappable;
 use Analogue\ORM\System\Cache\AttributeCache;
 use Analogue\ORM\System\Cache\InstanceCache;
-use Analogue\ORM\System\Wrappers\Wrapper;
-use Doctrine\Instantiator\Instantiator;
 use ErrorException;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -125,6 +123,7 @@ class Mapper
      * Map results to a Collection.
      *
      * @param array|Collection $results
+     * @param array            $eagerLoads
      *
      * @return Collection
      */
@@ -163,7 +162,7 @@ class Mapper
     /**
      * Return all records for a mapped object.
      *
-     * @return EntityCollection
+     * @return \Illuminate\Support\Collection
      */
     public function all()
     {
@@ -544,6 +543,8 @@ class Mapper
      * Return a new object instance using dependency injection.
      *
      * @param string $class
+     *
+     * @throws ErrorException
      *
      * @return mixed
      */

--- a/src/System/Proxies/CollectionProxy.php
+++ b/src/System/Proxies/CollectionProxy.php
@@ -17,15 +17,32 @@ class CollectionProxy extends EntityCollection implements ProxyInterface
      */
     protected $relationshipLoaded = false;
 
+    /**
+     * Added items.
+     *
+     * @var array
+     */
     protected $addedItems = [];
+
+    /**
+     * Parent entity.
+     *
+     * @var \Analogue\ORM\Mappable|string
+     */
+    protected $parentEntity;
+
+    /**
+     * Relationship.
+     *
+     * @var string
+     */
+    protected $relationshipMethod;
 
     /**
      * Create a new collection.
      *
      * @param mixed  $entity
      * @param string $relation
-     *
-     * @return void
      */
     public function __construct($entity, $relation)
     {
@@ -35,7 +52,7 @@ class CollectionProxy extends EntityCollection implements ProxyInterface
     }
 
     /**
-     * Return Items that has been added without lady loading
+     * Return Items that has been added without lazy loading
      * the underlying collection.
      *
      * @return array
@@ -637,7 +654,7 @@ class CollectionProxy extends EntityCollection implements ProxyInterface
     public function min($callback = null)
     {
         // TODO : we could rely on the QB
-        // for thos, if initialization has not
+        // for this, if initialization has not
         // take place yet
         $this->initializeProxy();
 

--- a/src/System/Query.php
+++ b/src/System/Query.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Collection;
 /**
  * Analogue Query builder.
  *
- * @mixin QueryAdapter|\Analogue\ORM\Drivers\IlluminateQueryAdapter
+ * @mixin QueryAdapter|\Analogue\ORM\Drivers\IlluminateQueryBuilder
  */
 class Query
 {
@@ -37,7 +37,7 @@ class Query
     /**
      * Query Builder Instance.
      *
-     * @var \Analogue\ORM\Drivers\QueryAdapter|\Analogue\ORM\Drivers\IlluminateQueryAdapter
+     * @var \Analogue\ORM\Drivers\QueryAdapter|\Analogue\ORM\Drivers\IlluminateQueryBuilder
      */
     protected $query;
 
@@ -640,7 +640,7 @@ class Query
      * (REFACTOR: this method should move out, we need to provide the client classes
      * with the adapter instead.)
      *
-     * @return \Analogue\ORM\Drivers\QueryAdapter|\Analogue\ORM\Drivers\IlluminateQueryAdapter
+     * @return \Analogue\ORM\Drivers\QueryAdapter|\Analogue\ORM\Drivers\IlluminateQueryBuilder
      */
     public function getQuery()
     {

--- a/src/System/Query.php
+++ b/src/System/Query.php
@@ -123,7 +123,7 @@ class Query
      *
      * @param array $columns
      *
-     * @return \Analogue\ORM\EntityCollection
+     * @return \Illuminate\Support\Collection
      */
     public function get($columns = ['*']) : Collection
     {
@@ -155,7 +155,7 @@ class Query
      * @param array $id
      * @param array $columns
      *
-     * @return EntityCollection
+     * @return \Illuminate\Support\Collection
      */
     public function findMany($id, $columns = ['*'])
     {
@@ -561,7 +561,7 @@ class Query
      *
      * @param array $columns
      *
-     * @return \Analogue\ORM\EntityCollection
+     * @return \Illuminate\Support\Collection
      */
     public function getEntities($columns = ['*'])
     {

--- a/src/System/Query.php
+++ b/src/System/Query.php
@@ -68,6 +68,7 @@ class Query
      * @var array
      */
     protected $passthru = [
+        'cursor',
         'toSql',
         'lists',
         'pluck',

--- a/src/System/ResultBuilder.php
+++ b/src/System/ResultBuilder.php
@@ -38,7 +38,6 @@ class ResultBuilder
 
     /**
      * @param Mapper $defaultMapper
-     * @param array  $eagerLoads
      */
     public function __construct(Mapper $defaultMapper)
     {
@@ -52,7 +51,7 @@ class ResultBuilder
      * @param array $results
      * @param array $eagerLoads name of the relation to be eager loaded on the Entities
      *
-     * @return \Illuminate\Support\Collection
+     * @return array
      */
     public function build(array $results, array $eagerLoads)
     {
@@ -341,7 +340,7 @@ class ResultBuilder
      *
      * @param array $results
      *
-     * @return Collection
+     * @return array
      */
     protected function buildWithDefaultMapper(array $results)
     {
@@ -357,7 +356,7 @@ class ResultBuilder
      *
      * @param array $results
      *
-     * @return Collection
+     * @return array
      */
     protected function buildUsingSingleTableInheritance(array $results)
     {

--- a/src/System/Wrappers/ObjectWrapper.php
+++ b/src/System/Wrappers/ObjectWrapper.php
@@ -42,10 +42,9 @@ class ObjectWrapper extends Wrapper
     /**
      * Object Wrapper constructor.
      *
-     * @param mixed                  $object
-     * @param Analogue\ORM\EntityMap $entityMap
-     *
-     * @return void
+     * @param mixed                   $entity
+     * @param \Analogue\ORM\EntityMap $entityMap
+     * @param HydratorInterface       $hydrator
      */
     public function __construct($entity, $entityMap, HydratorInterface $hydrator)
     {
@@ -108,7 +107,7 @@ class ObjectWrapper extends Wrapper
         $properties = $this->propertiesFromAttributes($this->attributes) + $this->unmanagedProperties;
 
         // In some case, attributes will miss some properties, so we'll just complete the hydration
-        // set with the orginal's object properties
+        // set with the original object properties
         $missingProperties = array_diff_key($this->properties, $properties);
 
         foreach (array_keys($missingProperties) as $missingKey) {
@@ -136,6 +135,8 @@ class ObjectWrapper extends Wrapper
      * Convert object's properties to analogue's internal attributes representation.
      *
      * @param array $properties
+     *
+     * @throws MappingException
      *
      * @return array
      */

--- a/src/System/Wrappers/Wrapper.php
+++ b/src/System/Wrappers/Wrapper.php
@@ -25,7 +25,7 @@ abstract class Wrapper implements InternallyMappable
     protected $entityMap;
 
     /**
-     * @var \Analogue\ORM\System\Proxirs\ProxyFactory
+     * @var \Analogue\ORM\System\Proxies\ProxyFactory
      */
     protected $proxyFactory;
 
@@ -64,7 +64,7 @@ abstract class Wrapper implements InternallyMappable
 
     /**
      * Return the Entity class/primary key couple,
-     * which is used for internall operations.
+     * which is used for internal operations.
      *
      * @return string
      */
@@ -94,7 +94,7 @@ abstract class Wrapper implements InternallyMappable
     }
 
     /**
-     * Set the lazyloading proxies on the wrapped entity objet.
+     * Set the lazy loading proxies on the wrapped entity objet.
      *
      * @param array $relations list of relations to be lazy loaded
      *


### PR DESCRIPTION
Like expressed in the title, this pull request contains fixes for the following:

- Missing or unused imports;
- Typos
- PHPdocs

Besides that, I also added the `cursor` method to the passthru `array` of the `Query` class (basically what I needed, but then I got carried away and started fixing more stuff 😂).