### PR TITLE
Fix erroneous sequence usage

### DIFF
--- a/src/Commands/Store.php
+++ b/src/Commands/Store.php
@@ -181,14 +181,12 @@ class Store extends Command
         if (array_key_exists($keyName, $attributes) && $attributes[$keyName] != null) {
             $this->query->insert($attributes);
         } else {
-            $sequence = $aggregate->getEntityMap()->getSequence();
-
             // Prevent inserting with a null ID
             if (array_key_exists($keyName, $attributes)) {
                 unset($attributes[$keyName]);
             }
 
-            $id = $this->query->insertGetId($attributes, $sequence);
+            $id = $this->query->insertGetId($attributes, $keyName);
 
             $aggregate->setEntityAttribute($keyName, $id);
         }

--- a/src/EntityMap.php
+++ b/src/EntityMap.php
@@ -212,14 +212,6 @@ class EntityMap
     protected $morphClass;
 
     /**
-     * Sequence name, to be used with postgreSql
-     * defaults to %table_name%_id_seq.
-     *
-     * @var string
-     */
-    protected $sequence;
-
-    /**
      * Indicates if the entity should be timestamped.
      *
      * @var bool
@@ -448,20 +440,6 @@ class EntityMap
     public function setTable(string $table)
     {
         $this->table = $table;
-    }
-
-    /**
-     * Get the pgSql sequence name.
-     *
-     * @return string
-     */
-    public function getSequence()
-    {
-        if (isset($this->sequence)) {
-            return $this->sequence;
-        }
-
-        return $this->getTable().'_id_seq';
     }
 
     /**


### PR DESCRIPTION
I found a bug in postgres insertGetId usage.

This fails with Postgres:

```php
    $userMapper = Analogue::mapper(User::class);
    $user = new User('John');
    $userMapper->store($user);
```

With simply a blank User entity and UserMap. The following error is returned:

```
[2018-01-21 12:06:38] local.ERROR: SQLSTATE[42703]: Undefined column: 7 ERROR:  column "users_id_seq" does not exist
LINE 1: ...nsert into "users" ("name") values ($1) returning "users_id_...
                                                             ^ (SQL: insert into "users" ("name") values (John) returning "users_id_seq") {"userId":1,"email":"test@test.test","exception":"[object] (Illuminate\\Database\\QueryException(code: 42703): SQLSTATE[42703]: Undefined column: 7 ERROR:  column \"users_id_seq\" does not exist
LINE 1: ...nsert into \"users\" (\"name\") values ($1) returning \"users_id_...
                                                             ^ (SQL: insert into \"users\" (\"name\") values (John) returning \"users_id_seq\") at /server/http/vendor/laravel/framework/src/Illuminate/Database/Connection.php:664, PDOException(code: 42703): SQLSTATE[42703]: Undefined column: 7 ERROR:  column \"users_id_seq\" does not exist
LINE 1: ...nsert into \"users\" (\"name\") values ($1) returning \"users_id_...
```

Looking closer at the source of the problem, it's this erroneous query:

```sql
insert into "users" ("name") values (John) returning "users_id_seq"
```

Which should be:

```sql
insert into "users" ("name") values (John) returning "id"
```

This PR fixes the described bug, and also removes `getSequence` entirely as it's now unused according to my IDE and searches.