### PR TITLE
Set has many relationships to empty collection instead of null

### DIFF
--- a/src/Relationships/HasOneOrMany.php
+++ b/src/Relationships/HasOneOrMany.php
@@ -204,8 +204,7 @@ abstract class HasOneOrMany extends Relationship
                 // TODO : Refactor This
                 $cache->cacheLoadedRelationResult($key, $relation, $value, $this);
             } else {
-                // TODO set an empty collection or entityCollection if type is many ?
-                $result[$relation] = null;
+                $result[$relation] = $type === 'many' ? $this->relatedMap->newCollection() : null;
             }
 
             return $result;


### PR DESCRIPTION
Using eager loading with an empty result and setting if we set the relation to null then it will be converted to a CollectionProxy (as for lazy loading) but it is better to init to an empty collection to prevent double loading (and n+1 problem)