### PR TITLE
Fix Missing Attribute with asJson

### DIFF
--- a/src/Relationships/EmbedsMany.php
+++ b/src/Relationships/EmbedsMany.php
@@ -45,7 +45,7 @@ class EmbedsMany extends EmbedsOne
         $key = $this->relation;
 
         if (!array_key_exists($key, $attributes)) {
-            $attributes[$key] = [];
+            $attributes[$key] = $this->asJson ? json_encode([]) : [];
         }
 
         if ($this->asJson) {


### PR DESCRIPTION
If it is set asJson the missing attribute must be a string (the json encoded version of an empty array)