### PR TITLE
Simplify Entity fill

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -130,12 +130,7 @@ class Entity extends ValueObject
     public function fill(array $attributes)
     {
         foreach ($attributes as $key => $attribute) {
-            if ($this->hasSetMutator($key)) {
-                $method = 'set'.$this->getMutatorMethod($key);
-                $this->attributes[$key] = $this->$method($attribute);
-            } else {
-                $this->attributes[$key] = $attribute;
-            }
+            $this->{$key} = $attribute;
         }
     }
 }


### PR DESCRIPTION
There is a bug on line 135 because the set mutator doesn't have to return the assigned value so the attribute will be set to null instead of the correct value.
However all the logic of the `fill` method can be removed simply assinging the value to the key and let the `_set` magic method do the work