### PR TITLE
Fixed incomplete BelongsToMany eager loads (#273)

### DIFF
--- a/src/Commands/Store.php
+++ b/src/Commands/Store.php
@@ -150,7 +150,7 @@ class Store extends Command
 
         // Now we can sync the related collections
         //
-        // TODO (note) : not sute this check is needed, as we can assume
+        // TODO (note) : not sure this check is needed, as we can assume
         // the aggregate exists in the Post Store Process
         if ($this->aggregate->exists()) {
             $this->aggregate->syncRelationships($foreignRelationships);

--- a/src/Relationships/BelongsToMany.php
+++ b/src/Relationships/BelongsToMany.php
@@ -205,7 +205,7 @@ class BelongsToMany extends Relationship
 
         $select = $this->getSelectColumns($columns);
 
-        $entities = $this->query->addSelect($select)->get()->all();
+        $entities = $this->query->addSelect($select)->disableCache()->get()->all();
 
         $entities = $this->hydratePivotRelation($entities);
 
@@ -217,28 +217,29 @@ class BelongsToMany extends Relationship
      *
      * @param array $entities
      *
-     * @return void
+     * @return array
      */
     protected function hydratePivotRelation(array $entities)
     {
         // TODO (note) We should definitely get rid of the pivot in a next
         // release, as this is not quite relevant in a datamapper context.
-        $host = $this;
-
-        return array_map(function ($entity) use ($host) {
+        return array_map(function ($entity) {
             $entityWrapper = $this->factory->make($entity);
 
-            $pivot = $this->newExistingPivot($this->cleanPivotAttributes($entityWrapper));
+            $pivotAttributes = $this->cleanPivotAttributes($entityWrapper);
+            $pivot = $this->newExistingPivot($pivotAttributes);
             $entityWrapper->setEntityAttribute('pivot', $pivot);
 
-            return $entityWrapper->getObject();
+            $object = $entityWrapper->unwrap();
+
+            return $object;
         }, $entities);
     }
 
     /**
      * Get the pivot attributes from a model.
      *
-     * @param  $entity
+     * @param InternallyMappable $entity
      *
      * @return array
      */
@@ -442,7 +443,9 @@ class BelongsToMany extends Relationship
         // children back to their parent using the dictionary and the keys on the
         // the parent models. Then we will return the hydrated models back out.
         return array_map(function ($result) use ($dictionary, $keyName, $cache, $relation, $host) {
-            if (isset($dictionary[$key = $result[$keyName]])) {
+            $key = $result[$keyName];
+
+            if (isset($dictionary[$key])) {
                 $collection = $host->relatedMap->newCollection($dictionary[$key]);
 
                 $result[$relation] = $collection;
@@ -475,7 +478,10 @@ class BelongsToMany extends Relationship
 
         foreach ($results as $entity) {
             $wrapper = $this->factory->make($entity);
-            $dictionary[$wrapper->getEntityAttribute('pivot')->$foreign][] = $entity;
+
+            $foreignKey = $wrapper->getEntityAttribute('pivot')->$foreign;
+
+            $dictionary[$foreignKey][] = $entity;
         }
 
         return $dictionary;
@@ -614,8 +620,6 @@ class BelongsToMany extends Relationship
         $query->where($this->foreignKey, '=', $this->parent->getEntityAttribute($parentKey));
 
         $query->delete();
-
-        $query = $this->newPivotQuery();
     }
 
     /**

--- a/src/Relationships/EmbeddedRelationship.php
+++ b/src/Relationships/EmbeddedRelationship.php
@@ -217,7 +217,7 @@ abstract class EmbeddedRelationship
      */
     protected function buildEmbeddedObject(array $attributes)
     {
-        $resultBuilder = new ResultBuilder($this->getRelatedMapper());
+        $resultBuilder = new ResultBuilder($this->getRelatedMapper(), true);
 
         // TODO : find a way to support eager load within an embedded
         // object.

--- a/src/Relationships/HasManyThrough.php
+++ b/src/Relationships/HasManyThrough.php
@@ -6,6 +6,7 @@ use Analogue\ORM\EntityCollection;
 use Analogue\ORM\System\Mapper;
 use Analogue\ORM\System\Query;
 use Illuminate\Database\Query\Expression;
+use Illuminate\Support\Collection;
 
 class HasManyThrough extends Relationship
 {
@@ -217,7 +218,7 @@ class HasManyThrough extends Relationship
      *
      * @return EntityCollection
      */
-    public function get($columns = ['*'])
+    public function get($columns = ['*']): Collection
     {
         // First we'll add the proper select columns onto the query so it is run with
         // the proper columns. Then, we will get the results and hydrate out pivot

--- a/src/System/Builders/EntityBuilder.php
+++ b/src/System/Builders/EntityBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Analogue\ORM\System\Builders;
 
+use Analogue\ORM\System\InternallyMappable;
 use Analogue\ORM\System\Mapper;
 use Analogue\ORM\System\Wrappers\Factory;
 
@@ -44,12 +45,18 @@ class EntityBuilder
     protected $factory;
 
     /**
+     * @var bool
+     */
+    protected $useCache;
+
+    /**
      * EntityBuilder constructor.
      *
      * @param Mapper $mapper
      * @param array  $eagerLoads
+     * @param bool   $useCache
      */
-    public function __construct(Mapper $mapper, array $eagerLoads)
+    public function __construct(Mapper $mapper, array $eagerLoads, bool $useCache = false)
     {
         $this->mapper = $mapper;
 
@@ -58,6 +65,8 @@ class EntityBuilder
         $this->eagerLoads = $eagerLoads;
 
         $this->factory = new Factory();
+
+        $this->useCache = $useCache;
     }
 
     /**
@@ -65,13 +74,13 @@ class EntityBuilder
      *
      * @param array $attributes
      *
-     * @return array
+     * @return mixed
      */
     public function build(array $attributes)
     {
         // If the object we are building is a value object,
         // we won't be using the instance cache.
-        if ($this->entityMap->getKeyName() === null) {
+        if (!$this->useCache || $this->entityMap->getKeyName() === null) {
             return $this->buildEntity($attributes);
         }
 

--- a/src/System/Builders/ResultBuilderFactory.php
+++ b/src/System/Builders/ResultBuilderFactory.php
@@ -6,13 +6,13 @@ use Analogue\ORM\System\Mapper;
 
 class ResultBuilderFactory
 {
-    public function make(Mapper $mapper) : ResultBuilderInterface
+    public function make(Mapper $mapper, bool $skipCache = false) : ResultBuilderInterface
     {
         switch ($mapper->getEntityMap()->getInheritanceType()) {
             case 'single_table':
                 return new PolymorphicResultBuilder($mapper);
             default:
-                return new ResultBuilder($mapper);
+                return new ResultBuilder($mapper, !$skipCache);
         }
     }
 }

--- a/src/System/Builders/ResultBuilderInterface.php
+++ b/src/System/Builders/ResultBuilderInterface.php
@@ -4,5 +4,13 @@ namespace Analogue\ORM\System\Builders;
 
 interface ResultBuilderInterface
 {
+    /**
+     * Convert a result set into an array of entities.
+     *
+     * @param array $results    The results to convert into entities.
+     * @param array $eagerLoads Relationships to eagerly load for these results.
+     *
+     * @return mixed
+     */
     public function build(array $results, array $eagerLoads);
 }

--- a/src/System/Mapper.php
+++ b/src/System/Mapper.php
@@ -126,12 +126,13 @@ class Mapper
      *
      * @param array|Collection $results
      * @param array            $eagerLoads
+     * @param bool             $useCache
      *
      * @return Collection
      */
-    public function map($results, array $eagerLoads = []) : Collection
+    public function map($results, array $eagerLoads = [], $useCache = false) : Collection
     {
-        $builder = $this->newResultBuilder();
+        $builder = $this->newResultBuilder(!$useCache);
 
         if ($results instanceof Collection) {
             // Get underlying collection array
@@ -159,13 +160,15 @@ class Mapper
     /**
      * Return result builder used by this mapper.
      *
-     * @return ResultBuilder
+     * @param bool $skipCache
+     *
+     * @return ResultBuilderInterface
      */
-    protected function newResultBuilder() : ResultBuilderInterface
+    protected function newResultBuilder(bool $skipCache = false) : ResultBuilderInterface
     {
         $factory = new ResultBuilderFactory();
 
-        return $factory->make($this);
+        return $factory->make($this, $skipCache);
     }
 
     /**

--- a/src/System/Query.php
+++ b/src/System/Query.php
@@ -99,6 +99,13 @@ class Query
     ];
 
     /**
+     * Whether to use the mapper's entity caching.
+     *
+     * @var bool
+     */
+    protected $useCache = true;
+
+    /**
      * Create a new Analogue Query Builder instance.
      *
      * @param Mapper    $mapper
@@ -504,6 +511,32 @@ class Query
     }
 
     /**
+     * Disable loading results from the entity instance cache.
+     *
+     * Loaded entities will still be stored in the cache.
+     *
+     * @return \Analogue\ORM\System\Query
+     */
+    public function disableCache()
+    {
+        $this->useCache = false;
+
+        return $this;
+    }
+
+    /**
+     * Enable loading results from the entity instance cache.
+     *
+     * @return \Analogue\ORM\System\Query
+     */
+    public function enableCache()
+    {
+        $this->useCache = true;
+
+        return $this;
+    }
+
+    /**
      * Get the table for the current query object.
      *
      * @return string
@@ -577,7 +610,7 @@ class Query
         $results = $this->query->get($columns);
 
         // Pass result set to the mapper and return the EntityCollection
-        return $this->mapper->map($results, $this->getEagerLoads());
+        return $this->mapper->map($results, $this->getEagerLoads(), $this->useCache);
     }
 
     /**

--- a/src/System/Wrappers/Factory.php
+++ b/src/System/Wrappers/Factory.php
@@ -14,15 +14,16 @@ class Factory
      *
      * @throws \Analogue\ORM\Exceptions\MappingException
      *
-     * @return Wrapper
+     * @return ObjectWrapper
      */
     public function make($object)
     {
         $manager = Manager::getInstance();
 
-        // Instantiate hydrator. We'll need to optimize this and allow pre-generation
-        // of these hydrator, and get it, ideally, from the entityMap or the Mapper class,
-        // so it's only instantiated once
+        // Instantiate hydrator
+        // TODO: We'll need to optimize this and allow pre-generation
+        //       of these hydrators, and get it, ideally, from the entityMap or
+        //       the Mapper class, so it's only instantiated once
         $config = new Configuration(get_class($object));
 
         $hydratorClass = $config->createFactory()->getHydratorClass();

--- a/src/System/Wrappers/ObjectWrapper.php
+++ b/src/System/Wrappers/ObjectWrapper.php
@@ -75,6 +75,8 @@ class ObjectWrapper implements InternallyMappable
      * @param mixed                   $entity
      * @param \Analogue\ORM\EntityMap $entityMap
      * @param HydratorInterface       $hydrator
+     *
+     * @throws MappingException
      */
     public function __construct($entity, $entityMap, HydratorInterface $hydrator)
     {
@@ -155,6 +157,8 @@ class ObjectWrapper implements InternallyMappable
      * Extract entity attributes / properties to an array of attributes.
      *
      * @param mixed $entity
+     *
+     * @throws MappingException
      *
      * @return array
      */

--- a/tests/DomainTestCase.php
+++ b/tests/DomainTestCase.php
@@ -16,9 +16,9 @@ abstract class DomainTestCase extends AnalogueTestCase
     }
 
     /**
-     * Insert a User using raw DB query.
+     * Insert a User using a raw database query.
      *
-     * @return User
+     * @return int The ID of the inserted user
      */
     protected function insertUser()
     {
@@ -33,6 +33,21 @@ abstract class DomainTestCase extends AnalogueTestCase
             'identity_lastname'  => $faker->lastName,
             'created_at'         => Carbon::now(),
             'updated_at'         => Carbon::now(),
+        ]);
+    }
+
+    /**
+     * Insert a Group using a raw database query.
+     *
+     * @return int The ID of the inserted group
+     */
+    protected function insertGroup()
+    {
+        $faker = $this->faker();
+
+        return $this->rawInsert('groups', [
+            'id'   => $this->randId(),
+            'name' => $faker->sentence,
         ]);
     }
 }


### PR DESCRIPTION
This should fix issue #273.

It ensures that `ResultBuilder` always returns unkeyed results, as well as preventing belongs-to-many loads from hitting the cache for their results. These results are still cached, because if they're not, `Aggregate` tests start to fail (entity existence checks).

I'm not totally pleased with the number of classes this fix touches, but along with my new tests, this was the easiest way I could see to fix eager loading for belongs to many relationships.

I'd suggest changing all many-to-many tests to actually test against many entities on both sides of the relationship, rather than just one parent to many children.

Please feel free to close this if you have a better fix in mind.

Cheers!