### PR TITLE
feature - Add the ability to map columns to properties in two new ways.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,52 @@
 # Changelog
 
-## Analogue 5.3
+#### Version 5.6
+- Laravel 5.6 support
+- Bring back ability to map DB columns that name are not equals to the name of the attribute.
+- Add ability to map DB snake case columns to camel case properties on entities.
 
-- It is now possible to for the mapper to use IoC when instantiating entities.
-- Native implementation of Single Table Inheritance pattern.
+#### Version 5.5
+- Laravel 5.5 support
+- Pushed miminum requirements to PHP7
+- Complete support of Plain PHP objects via reflection based hydration/dehydration
+- Improved Lazy-loading proxies.
+- New, more flexible Value Object implementation, that can now be defined as `embedsOne()`, `embedsMany()` relationships
+- Embedded value object can now be stored as a mysql JSON field
+- Analogue entities can now be instantiated using laravel's `IoC Container` or any PSR-11 compatible container. 
+- Added [MongoDB](https://github.com/analogueorm/mongodb) driver.
+- Package auto discovery (L5.5)
+
+#### Version 5.4
+- Illuminate 5.4 Compatibility.
+- Add Abillity to map DB columns that name are not equals to the name of the attribute.
+
+#### Version 5.3
+- Illuminate 5.3 Compatibility. 
+- Now fully support Single Table Inheritance.
 - EntityCollection is now correctly keyed by id
+
+#### Version 5.1
+- Illuminate 5.1 + 5.2 Compatibility. 
+
+#### Version 5.0
+- Analogue version now mirrors illuminate version. 
+
+#### Version 2.1.3
+- Mutator feature in base Entity class.
+- Ability to add entities to a proxy collection without lazyloading it.
+
+### Version 2.1
+
+- Package is now framework agnostic.
+- Now support any plain object that implements Mappable interface.
+- Introducing a MappableTrait for quick implementation. 
+- Queries can now be run directly on the mapper Object. 
+- Store/Delete methods now accept a array and collections as argument.
+- EntityMap are now autodected when in the same namespace as the entity.
+- Base Entity class Supports hidden attributes.
+- Many workflow related improvements.
+
+### Version 2.0
+
+- Laravel 5 Support.
 

--- a/readme.md
+++ b/readme.md
@@ -122,6 +122,8 @@ Check the [Documentation](https://github.com/analogueorm/analogue/wiki) for more
 
 #### Version 5.6
 - Laravel 5.6 support
+- Bring back ability to map DB columns that name are not equals to the name of the attribute.
+- Add ability to map DB snake case columns to camel case properties on entities.
 
 #### Version 5.5
 - Laravel 5.5 support
@@ -136,7 +138,7 @@ Check the [Documentation](https://github.com/analogueorm/analogue/wiki) for more
 
 #### Version 5.4
 - Illuminate 5.4 Compatibility.
-- Add Abillity to map DB columns that name are not equals to the name of the attribute.
+- Add Ability to map DB columns that name are not equals to the name of the attribute.
 
 #### Version 5.3
 - Illuminate 5.3 Compatibility. 

--- a/src/LengthAwareEntityPaginator.php
+++ b/src/LengthAwareEntityPaginator.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Analogue\ORM;
+
+use Illuminate\Pagination\LengthAwarePaginator;
+
+class LengthAwareEntityPaginator extends LengthAwarePaginator
+{
+    /**
+     * Paginator constructor.
+     *
+     * @param mixed $items
+     * @param int   $total
+     * @param int   $perPage
+     * @param null  $currentPage
+     * @param array $options
+     */
+    public function __construct($items, $total, $perPage, $currentPage = null, array $options = [])
+    {
+        $items = $items instanceof EntityCollection ? $items : EntityCollection::make($items);
+
+        parent::__construct($items, $total, $perPage, $currentPage, $options);
+    }
+}

--- a/src/System/Proxies/CollectionProxy.php
+++ b/src/System/Proxies/CollectionProxy.php
@@ -1057,10 +1057,13 @@ class CollectionProxy extends EntityCollection implements ProxyInterface
         switch (func_num_args()) {
             case 1:
                 $parent->splice($offset);
+                break;
             case 2:
                 $parent->splice($offset, $length);
+                break;
             case 3:
                 $parent->splice($offset, $length, $replacement);
+                break;
         }
     }
 

--- a/src/System/Wrappers/ObjectWrapper.php
+++ b/src/System/Wrappers/ObjectWrapper.php
@@ -162,6 +162,14 @@ class ObjectWrapper implements InternallyMappable
     {
         $properties = $this->hydrator->extract($entity);
 
+        $attributesName = $this->entityMap->getAttributesArrayName();
+
+        if (isset($properties[$attributesName])) {
+            $properties[$attributesName] = $this->entityMap->getColumnNamesFromAttributes($properties[$attributesName]);
+        } else {
+            $properties = $this->entityMap->getColumnNamesFromAttributes($properties);
+        }
+
         $this->properties = $properties;
 
         $this->unmanagedProperties = array_except($properties, $this->getManagedProperties());
@@ -177,6 +185,14 @@ class ObjectWrapper implements InternallyMappable
     protected function hydrate()
     {
         $properties = $this->propertiesFromAttributes() + $this->unmanagedProperties;
+
+        $attributesName = $this->entityMap->getAttributesArrayName();
+
+        if (isset($properties[$attributesName])) {
+            $properties[$attributesName] = $this->entityMap->getAttributeNamesFromColumns($properties[$attributesName]);
+        } else {
+            $properties = $this->entityMap->getAttributeNamesFromColumns($properties);
+        }
 
         // In some case, attributes will miss some properties, so we'll just complete the hydration
         // set with the original object properties
@@ -336,7 +352,6 @@ class ObjectWrapper implements InternallyMappable
         }
 
         foreach ($relations as $relation) {
-
             // First, we check that the relation has not been already
             // set, in which case, we'll just pass.
             if (array_key_exists($relation, $attributes) && !is_null($attributes[$relation])) {

--- a/src/ValueMap.php
+++ b/src/ValueMap.php
@@ -35,6 +35,21 @@ class ValueMap
     protected $arrayName = null;
 
     /**
+     * Set this property to true if you wish to use camel case
+     * properties.
+     *
+     * @var bool
+     */
+    protected $camelCaseHydratation = false;
+
+    /**
+     * The mappings to hydrated/dehydrated properties.
+     *
+     * @var arrat
+     */
+    protected $mappings = [];
+
+    /**
      * @return array
      */
     public function getAttributes()
@@ -99,5 +114,100 @@ class ValueMap
         } else {
             return class_basename($this);
         }
+    }
+
+    /**
+     * Maps the names of the column names to the appropriate attributes
+     * of an entity if the $attributes property of an EntityMap is an
+     * associative array.
+     *
+     * @param array $array
+     *
+     * @return array
+     */
+    public function getAttributeNamesFromColumns($array)
+    {
+        if (!empty($this->mappings)) {
+            $newArray = [];
+            foreach ($array as $key => $value) {
+                $attributeName = isset($this->mappings[$key]) ? $this->mappings[$key] : $key;
+                $newArray[$attributeName] = $value;
+            }
+
+            return $newArray;
+        }
+
+        return $array;
+    }
+
+    /**
+     * Gets the entity attribute name of a given column in a table.
+     *
+     * @param string $columnName
+     *
+     * @return string
+     */
+    public function getAttributeNameForColumn($columnName)
+    {
+        if (!empty($this->mappings)) {
+            if (isset($this->mappings[$columnName])) {
+                return $this->mappings[$columnName];
+            }
+        }
+
+        return $columnName;
+    }
+
+    /**
+     * Gets the column name of a given entity attribute.
+     *
+     * @param string $attributeName
+     *
+     * @return string
+     */
+    public function getColumnNameForAttribute($attributeName)
+    {
+        if (!empty($this->mappings)) {
+            $flipped = array_flip($this->mappings);
+            if (isset($flipped[$attributeName])) {
+                return $flipped[$attributeName];
+            }
+        }
+
+        return $attributeName;
+    }
+
+    /**
+     * Maps the attribute names of an entity to the appropriate
+     * column names in the database if the $attributes property of
+     * an EntityMap is an associative array.
+     *
+     * @param array $array
+     *
+     * @return array
+     */
+    public function getColumnNamesFromAttributes($array)
+    {
+        if (!empty($this->mappings)) {
+            $newArray = [];
+            $flipped = array_flip($this->mappings);
+            foreach ($array as $key => $value) {
+                $attributeName = isset($flipped[$key]) ? $flipped[$key] : $key;
+                $newArray[$attributeName] = $value;
+            }
+
+            return $newArray;
+        }
+
+        return $array;
+    }
+
+    public function hasAttribute($attribute)
+    {
+        if (!empty($this->mappings)) {
+            return in_array($attribute, array_values($this->mappings));
+        }
+
+        return in_array($attribute, $attributes);
     }
 }

--- a/tests/cases/AggregateTest.php
+++ b/tests/cases/AggregateTest.php
@@ -20,6 +20,7 @@ class AggregateTest extends AnalogueTestCase
         $user = $this->factoryMake(User::class);
         $id = $this->randId();
         $user->id = $id;
+
         $this->mapper($user)->store($user);
         $this->seeInDatabase('users', ['id' => $id]);
     }

--- a/tests/cases/EntityTest.php
+++ b/tests/cases/EntityTest.php
@@ -1,8 +1,8 @@
 <?php
 
-
 use TestApp\Article;
 use TestApp\Blog;
+use TestApp\Movie;
 use TestApp\User;
 
 class EntityTest extends AnalogueTestCase
@@ -85,6 +85,34 @@ class EntityTest extends AnalogueTestCase
 
         $this->assertInstanceOf(User::class, $user);
         $this->assertInstanceOf(Blog::class, $user->blog);
+    }
+
+    /** @test */
+    public function we_can_access_mapped_columns()
+    {
+        $user = $this->factoryMake(User::class);
+        $mapper = $this->mapper($user);
+        $user->rememberToken = '123456';
+        $user->identity->fname = 'adro';
+        $mapper->store($user);
+        $id = $user->id;
+        $user = null;
+        $user = $mapper->find($id);
+        $this->assertEquals('123456', $user->rememberToken);
+        $this->assertEquals('adro', $user->identity->fname);
+    }
+
+    /** @test */
+    public function we_can_access_camel_case_properities()
+    {
+        $movie = new Movie('Analogue Tutorial');
+        $mapper = $this->mapper($movie);
+        $movie->setSomeText('analogue is awesome');
+        $mapper->store($movie);
+        $id = $movie->getId();
+        $movie = null;
+        $movie = $mapper->find($id);
+        $this->assertEquals('analogue is awesome', $movie->getSomeText());
     }
 
     /** @test */

--- a/tests/migrations/2016_10_20_155124_create_movies_table.php
+++ b/tests/migrations/2016_10_20_155124_create_movies_table.php
@@ -15,6 +15,7 @@ class CreateMoviesTable extends Migration
         Schema::create('movies', function (Blueprint $table) {
             $table->increments('id');
             $table->string('title');
+            $table->string('some_text')->nullable();
             $table->integer('realisator_id')->nullable();
         });
     }

--- a/tests/src/Identity.php
+++ b/tests/src/Identity.php
@@ -8,7 +8,7 @@ class Identity extends ValueObject
 {
     public function __construct($firstname, $lastname)
     {
-        $this->firstname = $firstname;
+        $this->fname = $firstname;
         $this->lastname = $lastname;
     }
 }

--- a/tests/src/Maps/IdentityMap.php
+++ b/tests/src/Maps/IdentityMap.php
@@ -11,5 +11,9 @@ class IdentityMap extends ValueMap
         'lastname',
     ];
 
+    protected $mappings = [
+        'firstname' => 'fname',
+    ];
+
     protected $arrayName = 'attributes';
 }

--- a/tests/src/Maps/MovieMap.php
+++ b/tests/src/Maps/MovieMap.php
@@ -14,6 +14,8 @@ class MovieMap extends EntityMap
         'realisator',
     ];
 
+    protected $camelCaseHydratation = true;
+
     protected $arrayName = null;
 
     public function realisator(Movie $movie)

--- a/tests/src/Maps/UserMap.php
+++ b/tests/src/Maps/UserMap.php
@@ -13,6 +13,10 @@ class UserMap extends EntityMap
 {
     public $timestamps = true;
 
+    protected $mappings = [
+        'remember_token' => 'rememberToken',
+    ];
+
     protected $embeddables = ['identity' => Identity::class];
 
     public function blog(User $user)

--- a/tests/src/Movie.php
+++ b/tests/src/Movie.php
@@ -15,6 +15,11 @@ class Movie
     protected $title;
 
     /**
+     * @var string
+     */
+    protected $someText;
+
+    /**
      * @var Realisator;
      */
     protected $realisator;
@@ -32,5 +37,20 @@ class Movie
     public function getRealisator()
     {
         return $this->realisator;
+    }
+
+    public function setSomeText(string $someText)
+    {
+        $this->someText = $someText;
+    }
+
+    public function getSomeText()
+    {
+        return $this->someText;
+    }
+
+    public function getId()
+    {
+        return $this->id;
     }
 }


### PR DESCRIPTION
- Bring back ability to map DB columns that name are not equals to the name of the attribute.
- Add ability to map DB snake case columns to camel case properties on entities.

I added this two features since we use Analogue hevely on our main project at work and we had to fork it a tweak it in order to be use with our messed up database. 

Thanks in advance 😃 