### PR TITLE
Query fix

### DIFF
--- a/src/System/Query.php
+++ b/src/System/Query.php
@@ -583,8 +583,26 @@ class Query
      */
     protected function enforceIdColumn($columns)
     {
-        if (!in_array($this->entityMap->getKeyName(), $columns)) {
-            $columns[] = $this->entityMap->getKeyName();
+        $primaryKey = $this->entityMap->getKeyName();
+        $escapedKeyName = preg_quote($primaryKey, '/');
+        $table = $this->entityMap->getTable();
+
+        $match = false;
+
+        foreach ($columns as $column) {
+            if (substr($column, -strlen($primaryKey)) === $primaryKey) {
+                if (strlen($column) === strlen($primaryKey)) {
+                    $match = true;
+                    break;
+                } elseif (preg_match("/\w+\s+(?:(?:(AS|as)\s+)?$escapedKeyName/", $column)) {
+                    $match = true;
+                    break;
+                }
+            }
+        }
+
+        if (!$match) {
+            $columns[] = "$table.$primaryKey AS $primaryKey";
         }
 
         return $columns;

--- a/tests/cases/QueryTest.php
+++ b/tests/cases/QueryTest.php
@@ -98,4 +98,22 @@ class QueryTest extends AnalogueTestCase
 
         $this->assertEquals([$blogA->id, $blogB->id], $ids->all());
     }
+
+    public function test_alias()
+    {
+        $user = $this->factoryCreateUid(User::class);
+        /** @var \Analogue\ORM\System\Mapper $userMapper */
+        $userMapper = $this->mapper($user);
+        $userMapper->store($user);
+        $userTable = $userMapper->getEntityMap()->getTable();
+        $primaryKey = $userMapper->getEntityMap()->getKeyName();
+        $this->clearCache();
+
+        $query = $userMapper->getQuery();
+        $query->select(["$userTable.$primaryKey as $primaryKey", 'identity_firstname', 'identity_lastname']);
+        $results = $query->get();
+
+        $this->assertCount(1, $results);
+        $this->assertEquals($user->id, $results->first()->id);
+    }
 }


### PR DESCRIPTION
The query object currently does not recognise the primary key as being present if it's in the form of `other_column AS primary_key`. This is not usually an issue, but if the query joins a table that has a column with the same name as the primary key (quite likely if the primary key is called `id`) then it becomes impossible to run the query without getting an "ambiguous column" error.

This makes it impossible to do sorting or filtering of objects by related tables, which was an inconvenience when we were using Analogue to get paginated lists of users.

This pull request changes the logic in `Query::enforceIdColumn`. It was checking for a column whose name was exactly equal to the primary key, and adds it if it was not found. It now checks for a column that *ends* with the primary key name, and then checks that it is a valid alias. The performance impact in the usual case (no aliasing) should be minimal.

I have also changed the automatically inserted id column from being `primary_key` to `table.primary_key AS primary_key`, to avoid the situation mentioned above happening with the automatically added identity column.

A test for this case has been added to `QueryTest`.